### PR TITLE
Escaping post.title to allow special characters

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -16,7 +16,7 @@ layout: nil
     {% for post in site.posts limit:15 %}
     <entry>
         <id>{{ post.url}}</id>
-        <title>{{ post.title }}</title>
+        <title>{{ post.title | xml_escape }}</title>
         <link href="{{ post.url }}"/>
         <published>{{ post.date | date_to_xmlschema }}</published>
         {% if post.excerpt %}


### PR DESCRIPTION
Because of the '&'  character in the title of a "q&a" post, the atom.xml doesn't parse. I hope this fixes the problem. See also https://validator.w3.org/feed/check.cgi?url=http%3A%2F%2Fcodurance.com%2Fatom.xml