### PR TITLE
Fix URL of Samir's personal blog post

### DIFF
--- a/_posts/2015-11-02-time-to-go.md
+++ b/_posts/2015-11-02-time-to-go.md
@@ -6,7 +6,7 @@ date: 2015-11-02 09:00:00 +00:00
 author: Samir Talwar
 canonical:
     name: my personal blog
-    href: http://monospacedmonologues.com/post/120952987040/conversations-about-conversations-at-socrates-uk
+    href: http://monospacedmonologues.com/post/132392975060/time-to-go
 image:
     src: /assets/img/custom/blog/time-to-go.jpg
     attribution:


### PR DESCRIPTION
The canonical information referenced an older blog post in Samir's personal blog. As a result, the end of the post was showing a link to un unrelated article instead of the same article on Samir's blog.
