### PR TITLE
Fix tag links and layout on tag pages

### DIFF
--- a/_includes/post.html
+++ b/_includes/post.html
@@ -14,7 +14,7 @@
               <ul class="list-unstyled list-inline blog-tags">
                 <li>
                     {% for tag in post.tags %}
-                        <i class="fa fa-tags"></i><a href="/blog/tag/{{ tag }}/">{{ tag }} </a>
+                        <i class="fa fa-tags"></i><a href="/blog/tag/{{ tag | downcase  }}/">{{ tag }} </a>
                     {% endfor %}
                 </li>
               </ul>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -28,7 +28,7 @@ group:
             <ul class="list-unstyled list-inline blog-tags">
               <li>
                 {% for tag in page.tags %}
-                    <i class="fa fa-tags"></i><a href="/blog/tag/{{ tag }}/">{{ tag }} </a>
+                    <i class="fa fa-tags"></i><a href="/blog/tag/{{ tag | downcase }}/">{{ tag }} </a>
                 {% endfor %}
               </li>
             </ul>

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -2,8 +2,8 @@
 layout: default
 title: Blog
 ---
-<div class="container">
-    <div class="row blog-page blog-item">
+<div class="container content">
+    <div class="row blog-page">
         <!-- Left Sidebar -->
         <div class="col-md-9 md-margin-bottom-60">
             <!--Blog Post-->
@@ -27,7 +27,7 @@ title: Blog
         <!-- End Left Sidebar -->
 
 <!-- Right Sidebar -->
-        <div class="col-md-3 magazine-page">
+        <div class="col-md-3">
             <!-- Blog Latest Tweets -->
            <div class="blog-twitter margin-bottom-30">
                 <a class="twitter-timeline" href="https://twitter.com/mashooq/codurance" data-widget-id="400789734676385792">Tweets from Codurance team</a>


### PR DESCRIPTION
- Tag links are now 'down-cased' to prevent 404's.
- Margin added to the top of the tags page
