### PR TITLE
Remove DZone from ShareThis menu 

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -153,7 +153,7 @@ group:
 <!-- Sharethis toolbar. Note this will not work in a local environment -->
 <script type="text/javascript">stLight.options({publisher: "8b795ed1-9577-43d1-9e4e-55c54306336b", doNotHash: false, doNotCopy: false, hashAddressBar: false});</script>
 <script>
-  var options={ "publisher": "8b795ed1-9577-43d1-9e4e-55c54306336b", "position": "left", "ad": { "visible": false, "openDelay": 5, "closeDelay": 0}, "chicklets": { "items": ["twitter", "linkedin", "googleplus", "dzone", "email"]}};
+  var options={ "publisher": "8b795ed1-9577-43d1-9e4e-55c54306336b", "position": "left", "ad": { "visible": false, "openDelay": 5, "closeDelay": 0}, "chicklets": { "items": ["twitter", "linkedin", "googleplus", "facebook", "email"]}};
   var st_hover_widget = new sharethis.widgets.hoverbuttons(options);
 </script>
 <!-- End Sharethis toolbar -->


### PR DESCRIPTION
Doesn't look like Dzone integrates with ShareThis any longer ...
