### PR TITLE
Fixed heading styles in blog posts

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,7 +17,7 @@
 <!-- CSS Global Compulsory -->
 <link rel="stylesheet" href="/assets/plugins/bootstrap/css/bootstrap.min.css">
 <link rel="stylesheet" href="/assets/css/style.css">
-<link rel="stylesheet" href="/assets/css/style.css">
+<link rel="stylesheet" href="/assets/css/blocks.css">
 <link rel="stylesheet" href="/assets/css/blog.style.css">
 
 <!-- CSS Implementing Plugins -->

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -12,7 +12,7 @@ group:
       <!--Blog Post-->
       <div class="news-v3 bg-color-white margin-bottom-30">
         <div class="news-v3-in shareThisButtons">
-          <h2>{{ page.title }}</h2>
+          <h1>{{ page.title }}</h1>
           <ul class="list-inline posted-info">
               <li>By {{ page.author || author_links }}</li>
               {% if page.date %}

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -287,6 +287,22 @@ body:last-child .btn-u, x:-moz-any-link {
 	margin-right: 10px;
 }
 
+.news-v3-in h1 {
+	font-size: 32px;
+    font-weight: 200;
+    margin: 0 0 20px;
+    line-height: 45px;
+    text-transform: uppercase;
+}
+
+.news-v3-in h2 {
+    margin-top: 30px;
+    margin-bottom: 10px;
+    font-size: 28px;
+    line-height: 35px;
+    text-transform: none;
+}
+
 /* Author */
 #author-img {
 	width: 100%;


### PR DESCRIPTION
Blog titles are now H1 uppercased.
H2 blog section headers are no longer uppercased.
