### PR TITLE
Fixed issue with tags containing spaces

### DIFF
--- a/_includes/post.html
+++ b/_includes/post.html
@@ -19,14 +19,14 @@
                 <li>
                     <i class="fa fa-tags"></i>
                     {% for tag in post.tags %}
-                        <a href="/blog/tag/{{ tag | downcase  }}/">{{ tag }} </a>
+                        <a href="/blog/tag/{{ tag | downcase | replace: ' ','-'}}/">{{ tag }} </a>
                     {% endfor %}
                 </li>
               </ul>
             </div>
         {% endif %}
     </div>
-</div>   
+</div>
 <div class="clearfix margin-bottom-20">
     <hr/>
-</div>                         
+</div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -19,7 +19,7 @@ group:
                 <li>Posted {{ page.date | date_to_string }}</li>
                 <li>
                     {% for tag in page.tags %}
-                      <a href="/blog/tag/{{ tag | downcase }}/"><i class="fa fa-tags"></i><span class="blog-tag-margin"> {{ tag }}</span></a> 
+                      <a href="/blog/tag/{{ tag | downcase | replace: ' ','-'}}/"><i class="fa fa-tags"></i><span class="blog-tag-margin"> {{ tag }}</span></a>
                     {% endfor %}
                 </li>
                {% endif %}


### PR DESCRIPTION
When you click on tag which contains white space we receive 404 page.
