### PR TITLE
Change scroll functionality to another method

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -48,25 +48,9 @@ $(document).ready(function() {
     }
   });
 
-    $('#services-button').click(function(){
-	var scrollableElement = getFirstScrollableElement(['html','body']);
-	
-	scrollableElement.animate({
+    $('#services-button').click(function(){	
+	$('html,body').animate({
 	    scrollTop: $('#services').offset().top
 	}, 600);
     });
-
-    function getFirstScrollableElement(elements){
-	var element;
-
-	while(element = elements.pop()){
-	    $element = $(element);
-
-	    if($element.scrollTop() > 0) return $element;
-
-	    if($element.scrollTop(1).scrollTop() > 0) return $element.scrollTop(0);
-	}
-
-	return $();
-    }
 });


### PR DESCRIPTION
Felipe pointed out that the scroll functionality didn't work for him. The helper function 'getScrollableElement' in custom.js was supposed to select the right browser element (html or body) to use for the given browser. However, there is some edge case that it isn't catching.

By changing the functionality to choose both html AND body to execute the animation on, the edge case is covered. 
I didn't choose this functionality initially when I was researching scrolling as it seemed wrong to try an animation twice in order to get it to work once. Apparently this is the state of cross browser development :) . I haven't found a case of any browser having both html AND body as scrollable elements, it's either one or the other. Really though, there doesn't seem to be much info on this.
If anyone has more knowledge in this area it would be great to hear it :)
