### PR TITLE
Revert back to original position for logo

### DIFF
--- a/assets/css/headers/header-default.css
+++ b/assets/css/headers/header-default.css
@@ -148,7 +148,7 @@ body.header-fixed-space-default {
 /*Header Container*/
 .header > .container {
 	display: table;
-	margin-bottom: -20px;
+	margin-bottom: -40px;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
There were two solutions for fixing the logo-navigation overlap, they were both merged. Speaking with Giulia we want to stick with the thinner nav bar and reposition the logo back down.

![image](https://cloud.githubusercontent.com/assets/3209691/15959764/3524e6a0-2ef4-11e6-97d9-12fb9e3880e0.png)
