### PR TITLE
Add new tags to posts

### DIFF
--- a/_posts/2016-05-13-initiative-circles.md
+++ b/_posts/2016-05-13-initiative-circles.md
@@ -11,7 +11,7 @@ tags:
 - organisation
 - decision-making
 - transparency
-- culture
+- culture 
 ---
 
 We have been trying to encourage decentralised decision making at Codurance. To that effect, everyone within the company understands that they have the power to make any decision they need to make so long as they seek advise from the people that may be impacted. In order to help people make effective decisions, all company information is available to everyone in the company, including financials and salaries. This is all well and good, but in practice people do not simply go and start making informed strategic decisions just because they have the power to do so. For one, they are busy with their day jobs and simply do not have much time to look at the company holistically. Even if they have some wonderful ideas, they may not have the inclination or confidence to kick-off the initiative.

--- a/_posts/2016-05-13-initiative-circles.md
+++ b/_posts/2016-05-13-initiative-circles.md
@@ -6,9 +6,12 @@ date: 2016-05-13 00:20:00 +00:00
 author: Mashooq Badar 
 image:
    src: /assets/img/custom/blog/penguins.jpg
+category: practices
 tags:
-- codurance 
 - organisation
+- decision-making
+- transparency
+- culture
 ---
 
 We have been trying to encourage decentralised decision making at Codurance. To that effect, everyone within the company understands that they have the power to make any decision they need to make so long as they seek advise from the people that may be impacted. In order to help people make effective decisions, all company information is available to everyone in the company, including financials and salaries. This is all well and good, but in practice people do not simply go and start making informed strategic decisions just because they have the power to do so. For one, they are busy with their day jobs and simply do not have much time to look at the company holistically. Even if they have some wonderful ideas, they may not have the inclination or confidence to kick-off the initiative.

--- a/_posts/2016-05-14-retrospective-park.md
+++ b/_posts/2016-05-14-retrospective-park.md
@@ -9,10 +9,16 @@ canonical:
     href: http://blog.matthewbutt.com/2016/05/14/a-retrospective-in-the-park
 image:
     src: /assets/img/custom/blog/2016-05-14-retrospective-park/hibiscus.jpg
+categories: practices
 tags:
 - agile 
+- scrum
+- iteration
+- sprint
 - retrospective
-- practices
+- outdoor-retrospective
+- team
+- collaboration
 ---
 
 The other day, I facilitated a sprint retrospective in the park. The sun was shining, and we had all been working hard to complete our backlog, so it felt like a nice reward for everyone’s efforts. Holding a retrospective outdoors can also give it an energy and sense of enthusiasm that is harder to find in a small room.

--- a/_posts/2016-05-14-retrospective-park.md
+++ b/_posts/2016-05-14-retrospective-park.md
@@ -9,7 +9,7 @@ canonical:
     href: http://blog.matthewbutt.com/2016/05/14/a-retrospective-in-the-park
 image:
     src: /assets/img/custom/blog/2016-05-14-retrospective-park/hibiscus.jpg
-categories: practices
+category: practices
 tags:
 - agile 
 - scrum

--- a/_posts/2016-06-07-why-socrates-uk-is-not-just-a-conference-for-software-craftsmen.md
+++ b/_posts/2016-06-07-why-socrates-uk-is-not-just-a-conference-for-software-craftsmen.md
@@ -6,10 +6,15 @@ date: 2016-06-07 15:20:00 +00:00
 author: Giulia Mantuano
 image:
     src: /assets/img/custom/blog/socrates.jpg
+category: community
 tags:
+- event
 - socrates
-- conference
-- craftsmanship
+- software-craftsmanship
+- design
+- interaction-design
+- ui
+- ux
 ---
 
 Last Friday, I attended the international [Software Craftsmanship and Testing conference](http://socratesuk.org/index.html) at the enchanting Wotton House, in Dorking. I was the only Designer among about 100 Developers.

--- a/_posts/2016-06-20-scaling-umbraco-on-windows-azure.md
+++ b/_posts/2016-06-20-scaling-umbraco-on-windows-azure.md
@@ -6,11 +6,15 @@ date: 2016-06-24 16:20:00 +00:00
 author: Halima Koundi
 image:
    src: /assets/img/custom/blog/2016-06-20-umbraco-on-azure/umbraco-on-azure.jpg
+category: technologies
 tags:
-- cloud 
+- cloud
+- cloud-services
 - windows-azure 
 - cms
 - umbraco
+- open-source
+- website-solution
 ---
 
 This is the first post of a three parts series about how to scale an Umbraco website on Windows Azure platform.


### PR DESCRIPTION
In order to provide our users a better interplay between content and services, we are going to add a related blog posts section to the bottom of the "How We Work" page and to each service page. To do that we need to add or select new tags to each of them as well as start using categories.
