### PR TITLE
Configure 404 page for analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ node_modules
 
 # intellij idea files
 *.iml
+Makefile

--- a/404.html
+++ b/404.html
@@ -15,3 +15,13 @@ permalink: /404.html
     </div>
     <!--End Error Block-->
 </div>
+
+<!-- send a 404 event to google analytics.
+	Source: https://gist.github.com/pwenzel/eb4f04552ef410f60406 -->
+<script>
+if(window.googleAnalyticsEvents){
+    window.googleAnalyticsEvents.functions.push( function(environment) {
+        environment.ga('send', 'event', 'error', '404', 'page: ' + document.location.pathname + document.location.search + ' ref: ' + document.referrer, {'nonInteraction': 1});
+    });
+}
+</script>

--- a/_includes/foot.html
+++ b/_includes/foot.html
@@ -17,5 +17,9 @@
     jQuery(document).ready(function() {
         App.init();
         Contact.initMap();
+        var gaEvents = window.googleAnalyticsEvents;
+        gaEvents.functions.forEach(function(fireEvent){
+            fireEvent(gaEvents.environment);
+        });
     });
 </script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -53,6 +53,8 @@
 
     ga('create', '{{site.googleanalytics.account}}', 'codurance.com');
     ga('send', 'pageview');
+    window.googleAnalyticsEvents = { environment: {ga:ga}, functions: []};
+    // fire all events at onload - see _includes/foot.html
 </script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.8.0/highlight.min.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>


### PR DESCRIPTION
https://trello.com/c/uDfRQF4i/8-adding-analytics-to-the-404-page-so-that-we-track-dead-links
