### PR TITLE
Add link to users posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -56,7 +56,7 @@ group:
               <div class="col-sm-9 pull-left">
                 <div class="blog-author-desc">
                   <div class="overflow-h">
-                    <h4>{{ member.name }}</h4>
+                    <span class="fn"><h4>{{ page.author | author_links}}</h4></span>
                     {% if member.twitter %}
                     <ul class="list-inline">
                         <li><a href="https://twitter.com/intent/tweet?text=.%20@{{ member.twitter }}%20Type%20your%20text%20here&url={{ site.url | uri_escape }}{{ page.url| uri_escape }}&via=codurance"><i class="fa fa-twitter"></i></a></li>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -56,7 +56,7 @@ group:
               <div class="col-sm-9 pull-left">
                 <div class="blog-author-desc">
                   <div class="overflow-h">
-                    <span class="fn"><h4>{{ page.author | author_links}}</h4></span>
+                    <h4>{{ page.author | author_links}}</h4>
                     {% if member.twitter %}
                     <ul class="list-inline">
                         <li><a href="https://twitter.com/intent/tweet?text=.%20@{{ member.twitter }}%20Type%20your%20text%20here&url={{ site.url | uri_escape }}{{ page.url| uri_escape }}&via=codurance"><i class="fa fa-twitter"></i></a></li>


### PR DESCRIPTION
https://trello.com/c/pTYGD35u/12-add-link-to-the-author-in-the-author-section-in-the-bottom-of-the-blog-post

before: <img width="800" alt="screen shot 2016-07-15 at 13 26 43" src="https://cloud.githubusercontent.com/assets/4199136/16872872/03d9b258-4a90-11e6-8697-6b152fe90ace.png">

after:
<img width="813" alt="screen shot 2016-07-15 at 13 23 56" src="https://cloud.githubusercontent.com/assets/4199136/16872873/03f4e212-4a90-11e6-9ed4-8be64dbd5362.png">

The link in "SANDRO MANCUSO"'s name points to http://codurance.com/blog/author/sandro-mancuso/, which will show the user's posts.
