### PR TITLE
Refactor 'How we work' and buttons styling

### DIFF
--- a/_includes/blog_call_to_action.html
+++ b/_includes/blog_call_to_action.html
@@ -1,13 +1,12 @@
 <div class="container content-md">
   <div class="row margin-bottom-20">
-    <div class="col-md-9 orange-section"> 
+    <div class="col-md-9 bg-orange"> 
       <div class="contact-us vertical-alignment-parent">
-		<div class="vertical-alignment-child"> 
-			<h3 class="reset-margin">Interested in deeper learning? 
-				<span class="browse-courses">
-					<a href="/services/training">BROWSE OUR COURSES</a> 
-				</span>
-			</h3> 
+		<div class="vertical-alignment-child">
+		    <h3 class="reset-margin margin-right-20">
+		        <span class="margin-right-20">Interested in deeper learning?</span>
+		        <a href="/services/training" class="btn btn-more btn-more-light animated margin-left-10">BROWSE OUR COURSES</a>
+		    </h3> 
 		</div>
       </div> 
     </div> 
@@ -25,14 +24,12 @@
 			<label class="cta-label cta-label-right">Your e-mail
 				<input class="form-control" type="email" name="_replyto" required>
 			</label>
-			
 			<br />
 			<label>Message
 				<textarea class="form-control" rows="10" name="body" required></textarea>
 			</label>
-			
 			<br />
-			<button id="Send" value="Send" class="btn-send-message" type="submit">SUBMIT</button>
+			<button id="Send" value="Send" class="btn btn-u btn-more animated pull-right" type="submit">SUBMIT</button>
 		</form>
 	</div>
   </div>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -52,9 +52,6 @@ body {
 	font-size: 14px;
 	line-height: 17px;
     }
-    .feature-panel .jumbotron .btn-services {
-	font-size: 12px;
-    }
 }
 
 .feature-panel .jumbotron {
@@ -72,18 +69,22 @@ body {
     color:white;
 }
 
-.feature-panel .jumbotron .btn-services {
-    background-color: transparent;
-    border: 1px solid white;
+.btn-more {
     border-radius: 6px;
-    color: white;
     font-size: 18px;
-    margin-top: 10px;
-    padding-top: 10px;
-    padding-bottom: 10px;
+    margin: 10px 0;
+    padding: 10px 30px;
 }
 
-.feature-panel .jumbotron .btn-services:hover {
+.btn-more:hover { transition: .3s; }
+
+.btn-more-light {
+    background-color: transparent;
+    border: 1px solid white;
+    color: white;
+}
+
+.btn-more-light:hover {
     background-color: white;
     color: #687074;
 }
@@ -256,69 +257,24 @@ body:last-child .btn-u, x:-moz-any-link {
 	width: 350px;
 }
 
-
 /* Homepage services section */
-#services .software-creation .service-card-top {
-    background-color: #cc0000;
-}
-#services .software-creation .service-card-bottom {
-    background-color: #ff0000;
-}
-#services .software-creation .service-card-bottom .btn-services-link {
-    background-color: #cc0000;
-}
 
-#services .expert-advice .service-card-top {
-    background-color:#dd4d00;
-}
-#services .expert-advice .service-card-bottom {
-    background-color:#ff6600;
-}
-#services .expert-advice .service-card-bottom .btn-services-link {
-    background-color: #dd4d00;
-}
-
-#services .training-coaching .service-card-top {
-    background-color:#ffaa00;
-}
-#services .training-coaching .service-card-bottom {
-    background-color:#ffcc33;
-}
-#services .training-coaching .service-card-bottom .btn-services-link {
-    background-color: #ffaa00;
-}
-
-#services .service-card-top {
-    padding: 30px 0px 30px 0px;
+.service-card-inner {
+    padding: 30px 5px;
     text-align: center;
 }
 
-#services .service-card-top img {
+.service-card-inner img {
     display: block;
-    margin: 0px auto 5px auto;
+    margin: 0 auto 5px auto;
 }
 
-#services .service-card-top h2 {
+.service-card-inner h2 {
     color: white;
 }
 
-#services .service-card-bottom {
-    text-align: center;
-    font-size: 15px;
-    padding: 40px 0px 30px 0px;
-}
-
-#services .service-card-bottom ul li {
-    color: white;
-    font-weight: bold;
-    font-family: "Open Sans", sans serif;
-}
-
-#services .service-card-bottom .btn-services-link {
-    color: white;
-    margin-top: 20px;
-    font-weight: bold;
-    font-family: "Open Sans", sans serif;
+.service-card li {
+    padding-bottom: 8px;
 }
 
 @media (max-width: 992px) {
@@ -327,8 +283,8 @@ body:last-child .btn-u, x:-moz-any-link {
     }
 }
 
-
 /*Content Boxes*/
+
 .content-boxes {
   margin-bottom: 15px;
 }
@@ -415,21 +371,6 @@ body:last-child .btn-u, x:-moz-any-link {
 .cta-contact-blog-box label {
 	display: inline;
 }
-.browse-courses {
-    display: inline-block;
-    padding: 10px;
-}
-
-.contact-us span.browse-courses a {
-    background: white;
-    color: #ff6600;
-    padding: 5px 10px;
-}
-
-.contact-us span.browse-courses a:hover {
-    background: #ff6600;
-    color: white;
-}
 
 .vertical-alignment-parent {
     display: table;
@@ -454,23 +395,6 @@ body:last-child .btn-u, x:-moz-any-link {
 }
 .cta-label-right {
     float: right;
-}
-
-.btn-send-message {
-    background: #fafafa;
-    color: #333333;
-    display: block;
-    border: 1px solid #333333;
-    border-radius: 6px;
-    height: 40px;
-    width: 150px;
-    margin: 0 0 0 auto;
-    font-size: 16px;
-}
-
-.btn-send-message:hover {
-    background: #333333;
-    color: white;
 }
 
 /* Author */
@@ -703,14 +627,6 @@ h3.subject-header {
 
 .contact-us h2, .contact-us h3 {
     color: white;
-}
-
-.contact-us a {
-    width: 300px;
-    padding: 10px 0px 10px 0px;
-    margin: 10px auto 0px auto;
-    border: 1px solid white;
-    border-radius: 6px;
 }
 
 .contact-us a:hover {
@@ -999,6 +915,36 @@ h2.gray-underline:after {
     border: solid 1px #ddd;
     margin: 15px 0;
 }
+
+.block-centered-condensed {
+    padding: 10px;
+}
+
+.block-centered-condensed h3 {
+    font-size: 16px;
+}
+
+.no-border, i.no-border { border: none; }
+
+/* Foreground colors */
+
+.white, p.white, ul.white li { color: white; }
+
+/* Background colors */
+
+.bg-dark-red { background-color: #cc0000; }
+
+.bg-red { background-color: #ff0000; }
+
+.bg-dark-orange { background-color: #dd4d00; }
+
+.bg-orange { background-color: #ff6600; }
+
+.bg-dark-yellow { background-color: #ffaa00; }
+
+.bg-yellow { background-color: #ffcc33; }
+
+.bg-white { background-color: #fff; }
 
 @media (max-width: 768px) {
     .practice {

--- a/blog/index.html
+++ b/blog/index.html
@@ -63,5 +63,3 @@ title: Blog
         </div>
     </div>
 </div>
-
-{% include blog_call_to_action.html %}

--- a/company/index.html
+++ b/company/index.html
@@ -85,47 +85,52 @@ title: Company
                     <h2>How we work</h2>
                 </div>
                 <p>The way we work is firmly grounded in Software Craftsmanship and Agile principles. We believe that software should continuously add value to the business with inherent quality that allows it to evolve along with the changing needs of the business.</p>
-                <div class="row news-v1">
-                    <div class="col-md-4 md-margin-bottom-40">
-                        <div class="news-v1-in bg-color-white">
-                            <h3 class="font-normal">Software Craftsmanship</h3>
-                            <p>Software Craftsmanship is at the heart of everything we do so we can continuously deliver value to the business with inherent quality. We understand that quality should not be a premium. We hone our skills through continuous practice. We constantly learn, teach and mentor in our team, our company and the wider software development industry.</p>
-                        </div>
-                    </div>
-                    <div class="col-md-4 md-margin-bottom-40">
-                        <div class="news-v1-in bg-color-white">
-                            <h3 class="font-normal">Agile and Lean</h3>
-                            <p>We believe that a good process constantly delivers incremental value to the business and provides fast feedback. This allows us to inspect, learn, and adapt. We don't prescribe specific processes. We help teams understand their options and make their own choices - whether that is Scrum, Kanban, or a mix of Agile practices.</p>
-                        </div>
-                    </div>
-                    <div class="col-md-4">
-                        <div class="news-v1-in bg-color-white">
-                            <h3 class="font-normal">Continuous Delivery</h3>
-                            <p>We understand that Continuous Delivery requires the organisation to be aligned in order to deliver value to stakeholders in frequent and small iterations. We are experts in release automation and setting up continuous delivery pipelines. We achieve continuous delivery through close attention to business needs, software quality, and XP practices.</p>
-                        </div>
-                    </div>
-                </div>
 
-                <div class="row news-v1">
-                    <div class="col-md-4 md-margin-bottom-40">
-                        <div class="news-v1-in bg-color-white">
-                            <h3 class="font-normal">Extreme Programming (XP)</h3>
-                            <p>Practices such as Test-Driven Development (TDD), Pair Programming, Continuous Integration and Shared Ownership are core to everyone at Codurance. This fits very well with our craftsmanship values. We are experts in these practices and use them with great effect. We run public training courses and community events to help our industry embed these practices.</p>
-                        </div>
-                    </div>
-                    <div class="col-md-4 md-margin-bottom-40">
-                        <div class="news-v1-in bg-color-white">
-                            <h3 class="font-normal">DevOps</h3>
-                            <p>DevOps is a culture that supports continuous delivery. We believe that release, operation, and maintenance of software are as much the responsibility of the software development team as building the building the features in the first place. We include production stability, monitoring, and maintenance features from the start.</p>
-                        </div>
-                    </div>
-                    <div class="col-md-4">
-                        <div class="news-v1-in bg-color-white">
-                            <h3 class="font-normal">Technology</h3>
-                            <p>Our focus is on JVM, .Net, Node.js, Mobile (iOS and Android) and Web Front-end technologies. We use automation tools such as Ansible, Puppet, Powershell, Jenkins, Team City, VS Team Services and Github. We excel at cloud deployment, especially using AWS and Microsoft Azure. All our craftsmen are polyglots covering many languages on these platforms.</p>
-                        </div>
-                    </div>
-                </div>
+				<div class="row">
+					<div class="col-sm-6 col-md-4">
+						<div class="block-centered equalheight thumbnail-style">
+							<i class="icon-heart icon-color-red no-border"></i>
+							<h3>Software Craftsmanship</h3>
+							<p>Software Craftsmanship is at the heart of everything we do so we can continuously deliver value to the business with inherent quality. We understand that quality should not be a premium. We hone our skills through continuous practice. We constantly learn, teach and mentor in our team, our company and the wider software development industry.</p>		            
+						</div>
+					</div>
+					<div class="col-md-4 col-sm-6">
+						<div class="block-centered equalheight thumbnail-style">
+							<i class="icon-paper-plane icon-color-red no-border"></i>
+							<h3>Agile and Lean</h3>
+							<p>We believe that a good process constantly delivers incremental value to the business and provides fast feedback. This allows us to inspect, learn, and adapt. We don't prescribe specific processes. We help teams understand their options and make their own choices - whether that is Scrum, Kanban, or a mix of Agile practices.</p>
+						</div>
+					</div>
+					<div class="col-md-4 col-sm-6">
+						<div class="block-centered equalheight thumbnail-style">
+							<i class="icon-reload icon-color-red no-border"></i>
+							<h3>Continuous Delivery</h3>
+							<p>We understand that Continuous Delivery requires the organisation to be aligned in order to deliver value to stakeholders in frequent and small iterations. We are experts in release automation and setting up continuous delivery pipelines. We achieve continuous delivery through close attention to business needs, software quality, and XP practices.</p>
+						</div>
+					</div>
+					<div class="col-md-4 col-sm-6">
+						<div class="block-centered equalheight thumbnail-style">
+							<i class="icon-control-forward icon-color-red no-border"></i>
+							<h3>Extreme Programming (XP)</h3>
+							<p>Practices such as Test-Driven Development (TDD), Pair Programming, Continuous Integration and Shared Ownership are core to everyone at Codurance. This fits very well with our craftsmanship values. We are experts in these practices and use them with great effect. We run public training courses and community events to help our industry embed these practices.</p>
+						</div>
+					</div>
+					<div class="col-md-4 col-sm-6">
+						<div class="block-centered equalheight thumbnail-style">
+							<i class="icon-settings icon-color-red no-border"></i>
+							<h3>DevOps</h3>
+							<p>DevOps is a culture that supports continuous delivery. We believe that release, operation, and maintenance of software are as much the responsibility of the software development team as building the building the features in the first place. We include production stability, monitoring, and maintenance features from the start.</p>
+						</div>
+					</div>
+					<div class="col-md-4 col-sm-6">
+						<div class="block-centered equalheight thumbnail-style">
+							<i class="icon-screen-desktop icon-color-red no-border"></i>
+							<h3>Technology</h3>
+							<p>Our focus is on JVM, .Net, Node.js, Mobile (iOS and Android) and Web Front-end technologies. We use automation tools such as Ansible, Puppet, Powershell, Jenkins, Team City, VS Team Services and Github. We excel at cloud deployment, especially using AWS and Microsoft Azure. All our craftsmen are polyglots covering many languages on these platforms.</p>			        
+						</div>
+					</div>
+				</div>
+							
                 <div class="row">
                     <div class="col-md-12">
                         <a id="contactus"></a>
@@ -161,7 +166,7 @@ title: Company
                                 </div>
                                 <div class="col-sm-12">
                                     <textarea rows="5" class="form-control margin-bottom-20" name="body" required placeholder="Type your message here ..."></textarea>
-                                    <button id="Send" value="Send" class="btn-u btn-u-sm pull-right" type="submit">Send</button>
+                                    <button id="Send" value="Send" class="btn btn-more btn-u animated pull-right" type="submit">Send</button>
                                 </div>
                             </form>
                         </div>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ layout: default
         <div class="jumbotron">
             <h1>Pragmatic, Skilled, Transparent.</h1>
 	    <h3>At Codurance we constantly deliver value by crafting exceptional software.</h3>
-	    <button class="btn btn-services animated" id="services-button">Discover our services</button>
+	    <button class="btn btn-more btn-more-light animated" id="services-button">Discover our services</button>
         </div>
 </div>
 <!-- Activity panel -->
@@ -44,75 +44,69 @@ layout: default
                 </div>
             {% endfor %}
         </div>
-        <div class="col-md-4 col-md-offset-4">
-            <a href="/blog" class="btn-u btn-block">View all blog posts...</a>
+        <div class="col-md-12 text-center">
+            <a href="/blog" role="button" class="btn btn-u btn-more animated">View all blog posts</a>
         </div>
     </div>
 </div>
 <!-- Services panel -->
 <div class="section gray-section" id="services">
     <div class="container container-space">
-	<div class="title-header">
+	    <div class="title-header">
             <h2>Our Services</h2>
         </div>
         <div class="row">
             <div class="col-md-4">
-		<div class="software-creation service-card">
-		    <div class="service-card-top">
-			<img src="/assets/img/custom/home/services/software-creation-icon.png" />
-			<h2>Software Creation</h2>
-		    </div>
-		    <div class="service-card-bottom">
-			<ul class="list-unstyled">
-			    <li>EMBEDDED CRAFTSMAN</li>
-			    <li>SELF-CONTAINED TEAMS (on-site & off-site)</li>
-			    <li>UX & UI DESIGN</li>
-			    <li>AGILE & CONTINUOUS DELIVERY</li>
-			</ul>
-			<a href="/services/software-creation">
-			    <button class="btn btn-services-link">LEARN MORE</button>
-			</a>
-		    </div>
-		</div>
-	    </div>
+		        <div class="service-card">
+		            <div class="service-card-inner bg-dark-red">
+			            <img src="/assets/img/custom/home/services/software-creation-icon.png" />
+			            <h2 class="white">Software Creation</h2>
+		            </div>
+		            <div class="service-card-inner bg-red">
+			            <ul class="list-unstyled white">
+			                <li>EMBEDDED CRAFTSMAN</li>
+			                <li>SELF-CONTAINED TEAMS (on-site & off-site)</li>
+			                <li>UX & UI DESIGN</li>
+			                <li>AGILE & CONTINUOUS DELIVERY</li>
+			            </ul>
+			            <a href="/services/software-creation"  role="button" class="btn btn-more btn-more-light animated">Learn more</a>
+		            </div>
+		        </div>
+	        </div>
             <div class="col-md-4">
-		<div class="expert-advice service-card">
-		    <div class="service-card-top">
-			<img src="/assets/img/custom/home/services/expert-advice-icon.png" />
-			<h2>Expert Advice</h2>
+		    <div class="service-card">
+		        <div class="service-card-inner bg-dark-orange">
+			        <img src="/assets/img/custom/home/services/expert-advice-icon.png" />
+			        <h2 class="white">Expert Advice</h2>
+		        </div>
+		        <div class="service-card-inner bg-orange">
+			        <ul class="list-unstyled white">
+			            <li>ENTERPRISE ARCHITECTURE & DESIGN</li>
+			            <li>MICROSERVICES & DEVOPS</li>
+			            <li>CLOUD SOLUTIONS (Amazon AWS & Azure)</li>
+			            <li>BUSINESS & TECHNOLOGY ALIGNMENT</li>
+			        </ul>
+			        <a href="/services/expert-advice" role="button" class="btn btn-more btn-more-light animated">Learn more</a>
+		        </div>
 		    </div>
-		    <div class="service-card-bottom">
-			<ul class="list-unstyled">
-			    <li>ENTERPRISE ARCHITECTURE & DESIGN</li>
-			    <li>MICROSERVICES & DEVOPS</li>
-			    <li>CLOUD SOLUTIONS (Amazon AWS & Azure)</li>
-			    <li>BUSINESS & TECHNOLOGY ALIGNMENT</li>
-			</ul>
-			<a href="/services/expert-advice">
-			    <button class="btn btn-services-link">LEARN MORE</button>
-			</a>
-		    </div>
-		</div>
-	    </div>
+	        </div>
             <div class="col-md-4">
-		<div class="training-coaching service-card">
-		    <div class="service-card-top">
-			<img src="/assets/img/custom/home/services/training-coaching-icon.png" />
-			<h2>Training & Coaching</h2>
-		    </div>
-		    <div class="service-card-bottom">
-			<ul class="list-unstyled">
-			    <li>TDD, CLEAN CODE & DESIGN</li>
-			    <li>CLOUD, ARCHITECTURE & MICROSERVICES</li>
-			    <li>MOBILE, JVM, .NET & DEVOPS</li>
-			    <li>GROWING A CRAFTSMANSHIP CULTURE</li>
-			</ul>
-			<a href="/services/training">
-			    <button class="btn btn-services-link">LEARN MORE</button>
-			</a>
-		    </div>
-		</div>
-	    </div>
+		        <div class="service-card">
+		            <div class="service-card-inner bg-dark-yellow">
+			            <img src="/assets/img/custom/home/services/training-coaching-icon.png" />
+			            <h2 class="white">Training & Coaching</h2>
+		            </div>
+		            <div class="service-card-inner bg-yellow">
+			            <ul class="list-unstyled white">
+			                <li>TDD, CLEAN CODE & DESIGN</li>
+			                <li>CLOUD, ARCHITECTURE & MICROSERVICES</li>
+			                <li>MOBILE, JVM, .NET & DEVOPS</li>
+			                <li>GROWING A CRAFTSMANSHIP CULTURE</li>
+			            </ul>
+			            <a href="/services/training" role="button" class="btn btn-more btn-more-light animated">Learn more</a>
+		            </div>
+		        </div>
+	        </div>
         </div>
     </div>
 </div>
@@ -185,51 +179,46 @@ layout: default
             <p>The way we work is firmly grounded in Software Craftsmanship and Agile principles. We believe that software should continuously add value to the business with inherent quality that allows it to evolve along with the changing needs of the business.</p>
         </div>
 		<div class="row">
-		    <div class="col-sm-6 col-md-4 ">
-		        <div class="block-centered equalheight">
-                    <i class="icon-heart"></i>
+		    <div class="col-sm-4 col-md-2">
+		        <div class="block-centered block-centered-condensed equalheight thumbnail-style bg-white">
+                    <i class="icon-custom icon-md icon-color-red icon-heart no-border"></i>
                     <h3>Software Craftsmanship</h3>
-                    <p>Software Craftsmanship is at the heart of everything we do so we can continuously deliver value to the business with inherent quality. We understand that quality should not be a premium. We hone our skills through continuous practice. We constantly learn, teach and mentor in our team, our company and the wider software development industry.</p>		            
 		        </div>
 		    </div>
-		    <div class="col-md-4 col-sm-6">
-		        <div class="block-centered equalheight">
-		            <i class="icon-paper-plane"></i>
+		    <div class="col-sm-4 col-md-2">
+		        <div class="block-centered block-centered-condensed equalheight thumbnail-style bg-white">
+		            <i class="icon-custom icon-md icon-color-red icon-paper-plane no-border"></i>
 		            <h3>Agile and Lean</h3>
-		            <p>We believe that a good process constantly delivers incremental value to the business and provides fast feedback. This allows us to inspect, learn, and adapt. We don't prescribe specific processes. We help teams understand their options and make their own choices - whether that is Scrum, Kanban, or a mix of Agile practices.</p>
 		        </div>
 		    </div>
-            <div class="clearfix visible-sm"></div>
-		    <div class="col-md-4 col-sm-6">
-		        <div class="block-centered equalheight">
-		            <i class="icon-reload"></i>
+		    <div class="col-sm-4 col-md-2">
+		        <div class="block-centered block-centered-condensed equalheight thumbnail-style bg-white">
+		            <i class="icon-custom icon-md icon-color-red icon-reload no-border"></i>
 		            <h3>Continuous Delivery</h3>
-		            <p>We understand that Continuous Delivery requires the organisation to be aligned in order to deliver value to stakeholders in frequent and small iterations. We are experts in release automation and setting up continuous delivery pipelines. We achieve continuous delivery through close attention to business needs, software quality, and XP practices.</p>
 		        </div>
 		    </div>
-            <div class="clearfix visible-md"></div>
-			<div class="col-md-4 col-sm-6">
-			    <div class="block-centered equalheight">
-                    <i class="icon-control-forward"></i>
-                    <h3>Extreme Programming (XP)</h3>
-                    <p>Practices such as Test-Driven Development (TDD), Pair Programming, Continuous Integration and Shared Ownership are core to everyone at Codurance. This fits very well with our craftsmanship values. We are experts in these practices and use them with great effect. We run public training courses and community events to help our industry embed these practices.</p>
+			<div class="col-sm-4 col-md-2">
+			    <div class="block-centered block-centered-condensed equalheight thumbnail-style bg-white">
+                    <i class="icon-custom icon-md icon-color-red icon-control-forward no-border"></i>
+                    <h3>Extreme Programming</h3>
 			    </div>
 			</div>
-            <div class="clearfix visible-sm"></div>
-			<div class="col-md-4 col-sm-6">
-			    <div class="block-centered equalheight">
-                    <i class="icon-settings"></i>
+			<div class="col-sm-4 col-md-2">
+			    <div class="block-centered block-centered-condensed equalheight thumbnail-style bg-white">
+                    <i class="icon-custom icon-md icon-color-red icon-settings no-border"></i>
                     <h3>DevOps</h3>
-                    <p>DevOps is a culture that supports continuous delivery. We believe that release, operation, and maintenance of software are as much the responsibility of the software development team as building the building the features in the first place. We include production stability, monitoring, and maintenance features from the start.</p>
 			    </div>
 			</div>
-			<div class="col-md-4 col-sm-6">
-			    <div class="block-centered equalheight">
-                    <i class="icon-screen-desktop"></i>
-                    <h3>Technology</h3>
-                    <p>Our focus is on JVM, .Net, Node.js, Mobile (iOS and Android) and Web Front-end technologies. We use automation tools such as Ansible, Puppet, Powershell, Jenkins, Team City, VS Team Services and Github. We excel at cloud deployment, especially using AWS and Microsoft Azure. All our craftsmen are polyglots covering many languages on these platforms.</p>			        
-			    </div>
-			</div>
+		    <div class="col-sm-4 col-md-2">
+		        <div class="block-centered block-centered-condensed equalheight thumbnail-style bg-white">
+		            <i class="icon-custom icon-md icon-color-red icon-screen-desktop no-border"></i>
+		            <h3>Technology</h3>
+		        </div>
+		    </div>
+            <div class="col-md-12 text-center">
+                <a href="/company/#howwework" class="btn btn-u btn-more animated">Learn more</a>
+            </div>
+
 		</div>
 	</div>
 </div>

--- a/services/expert-advice.html
+++ b/services/expert-advice.html
@@ -46,8 +46,8 @@ category:
 <div class="section orange-section">
     <div class="contact-us">
         <h3 class="margin-bottom-20">Our Software Craftsmen will help you find well-thought-out solutions to help your business grow.</h3>
-	<a href="/company/#contactus" class="btn-block">
-	    <h2>CONTACT US</h2>
+	<a href="/company/#contactus" class="btn btn-more btn-more-light animated">
+	    CONTACT US
 	</a>
     </div>
 </div>

--- a/services/software-creation.html
+++ b/services/software-creation.html
@@ -45,8 +45,8 @@ category:
 <div class="section red-section">
     <div class="contact-us">
         <h3 class="margin-bottom-20">Our Software Craftsmen will help you find well-thought-out solutions to help your business grow.</h3>
-	<a href="/company/#contactus" class="btn-block">
-	    <h2>CONTACT US</h2>
+	<a href="/company/#contactus" class="btn btn-more btn-more-light animated">
+	    CONTACT US
 	</a>
     </div>
 </div>

--- a/services/training.html
+++ b/services/training.html
@@ -178,8 +178,8 @@ category:
 <div class="section">
     <div class="contact-us contact-us-courses">
         <h3 class="margin-bottom-20">Our Software Craftsmen will help you find well-thought-out solutions to help your business grow.</h3>
-	<a href="/company/#contactus" class="btn-block">
-	    <h2>CONTACT US</h2>
+	<a href="/company/#contactus" class="btn btn-more btn-more-light animated">
+	    CONTACT US
 	</a> 
     </div>
 </div>


### PR DESCRIPTION
**Refactor 'How we work' sections and buttons styling**
- 'How we work' section on frontpage use only icon and title
- New button 'Learn more' below 'How we work' section on the frontpage
- 'How we work' section on company's page restyled
- Button style consistent and applied to frontpage, service pages and contact forms
- Hover transition on buttons
- A bit more spacing on the 'Service' section on the frontpage for better readability
- Remove link to training page and contact form on blog landing page
- Refactor background styles
- Remove unused styles in 'custom.css'
