### PR TITLE
Remove grey background from client logos (MERGE AFTER #399)

### DIFF
--- a/_includes/featured_events.html
+++ b/_includes/featured_events.html
@@ -4,9 +4,9 @@
 		<div class="blog-box homepage-blog-thumb">
 			<a href="{{ post.event-page-url }}">
 			{% if post.image.src %}
-				<img class="img-responsive" src="{{ post.image.src }}" alt="{{ post.title }}">
+				<img class="img-responsive bordered" src="{{ post.image.src }}" alt="{{ post.title }}">
 			{% else %}
-				<img class="img-responsive" src="/assets/img/coduranceLogoBlogThumb.png" alt="{{ postTitle }}" alt="{{ postTitle }}">
+				<img class="img-responsive bordered" src="/assets/img/coduranceLogoBlogThumb.png" alt="{{ postTitle }}" alt="{{ postTitle }}">
 			{% endif %}
 			</a>
 			<div class="blog-content">

--- a/_includes/latest_highlights.html
+++ b/_includes/latest_highlights.html
@@ -21,7 +21,7 @@
 	{% endif %}
 	<div class="col-md-4 md-margin-bottom-40">
 		<div class="blog-box homepage-blog-thumb">
-			<img class="img-responsive" src="{{ imageSrc }}" alt="{{ post.title }}">
+			<img class="img-responsive bordered" src="{{ imageSrc }}" alt="{{ post.title }}">
 			<div class="blog-content">
 				<h3><a href="{{ linkUrl }}">{{ post.title | truncatewords: 8 }}</a></h3>
 				<p>{{ introductionToPost | strip_html | truncatewords:30 }}</p>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -30,6 +30,10 @@ body {
     padding-right: 20px;
 }
 
+.bordered {
+  border: solid 1px #eee;
+}
+
 /* Home Page */
 
 .feature-panel {

--- a/assets/css/pages/page_clients.css
+++ b/assets/css/pages/page_clients.css
@@ -23,7 +23,7 @@
 .clients-page img {
 	padding: 4px;
 	margin: 5px 0; 
-	background: #fafafa;
+	background: white;
 }
 
 .clients-page:hover img {

--- a/assets/css/pages/page_clients.css
+++ b/assets/css/pages/page_clients.css
@@ -23,7 +23,6 @@
 .clients-page img {
 	padding: 4px;
 	margin: 5px 0; 
-	border: solid 1px #eee;
 	background: #fafafa;
 }
 

--- a/clients/index.html
+++ b/clients/index.html
@@ -28,7 +28,7 @@ title: Clients
 
     <div class="row clients-page">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/ubs.png" class="img-responsive hover-effect" alt="">
+        <img src="/assets/img/custom/home/clients/ubs.png" class="img-responsive hover-effect bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>UBS</h3>
@@ -42,7 +42,7 @@ title: Clients
 
     <div class="row clients-page">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/mergermarket.jpg" class="img-responsive hover-effect" alt="">
+        <img src="/assets/img/custom/home/clients/mergermarket.jpg" class="img-responsive hover-effect bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>Mergermarket</h3>
@@ -56,7 +56,7 @@ title: Clients
 
     <div class="row clients-page">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/societygenerale.jpg" class="img-responsive hover-effect" alt="">
+        <img src="/assets/img/custom/home/clients/societygenerale.jpg" class="img-responsive hover-effect bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>Societe Generale</h3>
@@ -70,7 +70,7 @@ title: Clients
 
     <div class="row clients-page">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/m&g.png" class="img-responsive hover-effect" alt="">
+        <img src="/assets/img/custom/home/clients/m&g.png" class="img-responsive hover-effect bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>M&G</h3>
@@ -84,7 +84,7 @@ title: Clients
 
     <div class="row clients-page" style="border-bottom: 0px">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/flextrade.png" class="img-responsive hover-effect" alt="">
+        <img src="/assets/img/custom/home/clients/flextrade.png" class="img-responsive hover-effect bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>Flextrade</h3>
@@ -107,7 +107,7 @@ title: Clients
 
     <div class="row clients-page">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/tesco.png" class="img-responsive hover-effect" alt="">
+        <img src="/assets/img/custom/home/clients/tesco.png" class="img-responsive hover-effect bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>Tesco</h3>
@@ -121,7 +121,7 @@ title: Clients
 
     <div class="row clients-page">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/asos-logo.jpg" class="img-responsive hover-effect" alt="">
+        <img src="/assets/img/custom/home/clients/asos-logo.jpg" class="img-responsive hover-effect bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>ASOS</h3>
@@ -135,7 +135,7 @@ title: Clients
 
     <div class="row clients-page" style="border-bottom: 0px">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/coniq.png" class="img-responsive hover-effect" alt="">
+        <img src="/assets/img/custom/home/clients/coniq.png" class="img-responsive hover-effect bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>Coniq</h3>
@@ -158,7 +158,7 @@ title: Clients
 
     <div class="row clients-page">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/crowdmix.jpg" class="img-responsive hover-effect" alt="">
+        <img src="/assets/img/custom/home/clients/crowdmix.jpg" class="img-responsive hover-effect bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>Crowdmix</h3>
@@ -172,7 +172,7 @@ title: Clients
 
     <div class="row clients-page">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/aws.jpg" class="img-responsive hover-effect" alt="">
+        <img src="/assets/img/custom/home/clients/aws.jpg" class="img-responsive hover-effect bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>Amazon Web Services</h3>
@@ -186,7 +186,7 @@ title: Clients
 
     <div class="row clients-page">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/trinitymirror.png" class="img-responsive hover-effect" alt="">
+        <img src="/assets/img/custom/home/clients/trinitymirror.png" class="img-responsive hover-effect bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>Trinity Mirror</h3>
@@ -200,7 +200,7 @@ title: Clients
 
     <div class="row clients-page" style="border-bottom: 0px">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/findmypast.jpg" class="img-responsive hover-effect" alt="">
+        <img src="/assets/img/custom/home/clients/findmypast.jpg" class="img-responsive hover-effect bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>Findmypast</h3>
@@ -223,7 +223,7 @@ title: Clients
 
     <div class="row clients-page">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/skillsmatter.jpg" class="img-responsive hover-effect" alt="">
+        <img src="/assets/img/custom/home/clients/skillsmatter.jpg" class="img-responsive hover-effect bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>Skills Matter</h3>
@@ -236,7 +236,7 @@ title: Clients
 
     <div class="row clients-page">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/jetbrainsLogo.png" class="img-responsive hover-effect" alt="">
+        <img src="/assets/img/custom/home/clients/jetbrainsLogo.png" class="img-responsive hover-effect bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>Jetbrains</h3>
@@ -249,7 +249,7 @@ title: Clients
 
     <div class="row clients-page" style="border-bottom: 0px">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/github.png" class="img-responsive hover-effect" alt="">
+        <img src="/assets/img/custom/home/clients/github.png" class="img-responsive hover-effect bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>Github</h3>


### PR DESCRIPTION
This background has uneven effects depending on the logo's size and background color. All our clients have a white background logo, and most communication departments will ensure that the logos go well behind a white background.

Before:

![image](https://cloud.githubusercontent.com/assets/1684420/18990339/0e21d032-8709-11e6-934f-3b32301d2de0.png)

After:

![image](https://cloud.githubusercontent.com/assets/1684420/18990350/19f497e6-8709-11e6-969f-a2076e658eaa.png)
