### PR TITLE
Remove hover effect on clients and how we work

### DIFF
--- a/assets/css/pages/page_clients.css
+++ b/assets/css/pages/page_clients.css
@@ -26,10 +26,6 @@
 	background: white;
 }
 
-.clients-page:hover img {
-	border-color: #bbb;
-}
-
 @media (max-width: 992px) { 
 	.clients-page {
 		text-align: center;

--- a/clients/index.html
+++ b/clients/index.html
@@ -28,7 +28,7 @@ title: Clients
 
     <div class="row clients-page">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/ubs.png" class="img-responsive hover-effect bordered" alt="">
+        <img src="/assets/img/custom/home/clients/ubs.png" class="img-responsive bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>UBS</h3>
@@ -42,7 +42,7 @@ title: Clients
 
     <div class="row clients-page">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/mergermarket.jpg" class="img-responsive hover-effect bordered" alt="">
+        <img src="/assets/img/custom/home/clients/mergermarket.jpg" class="img-responsive bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>Mergermarket</h3>
@@ -56,7 +56,7 @@ title: Clients
 
     <div class="row clients-page">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/societygenerale.jpg" class="img-responsive hover-effect bordered" alt="">
+        <img src="/assets/img/custom/home/clients/societygenerale.jpg" class="img-responsive bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>Societe Generale</h3>
@@ -70,7 +70,7 @@ title: Clients
 
     <div class="row clients-page">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/m&g.png" class="img-responsive hover-effect bordered" alt="">
+        <img src="/assets/img/custom/home/clients/m&g.png" class="img-responsive bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>M&G</h3>
@@ -84,7 +84,7 @@ title: Clients
 
     <div class="row clients-page" style="border-bottom: 0px">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/flextrade.png" class="img-responsive hover-effect bordered" alt="">
+        <img src="/assets/img/custom/home/clients/flextrade.png" class="img-responsive bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>Flextrade</h3>
@@ -107,7 +107,7 @@ title: Clients
 
     <div class="row clients-page">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/tesco.png" class="img-responsive hover-effect bordered" alt="">
+        <img src="/assets/img/custom/home/clients/tesco.png" class="img-responsive bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>Tesco</h3>
@@ -121,7 +121,7 @@ title: Clients
 
     <div class="row clients-page">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/asos-logo.jpg" class="img-responsive hover-effect bordered" alt="">
+        <img src="/assets/img/custom/home/clients/asos-logo.jpg" class="img-responsive bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>ASOS</h3>
@@ -135,7 +135,7 @@ title: Clients
 
     <div class="row clients-page" style="border-bottom: 0px">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/coniq.png" class="img-responsive hover-effect bordered" alt="">
+        <img src="/assets/img/custom/home/clients/coniq.png" class="img-responsive bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>Coniq</h3>
@@ -158,7 +158,7 @@ title: Clients
 
     <div class="row clients-page">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/crowdmix.jpg" class="img-responsive hover-effect bordered" alt="">
+        <img src="/assets/img/custom/home/clients/crowdmix.jpg" class="img-responsive bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>Crowdmix</h3>
@@ -172,7 +172,7 @@ title: Clients
 
     <div class="row clients-page">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/aws.jpg" class="img-responsive hover-effect bordered" alt="">
+        <img src="/assets/img/custom/home/clients/aws.jpg" class="img-responsive bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>Amazon Web Services</h3>
@@ -186,7 +186,7 @@ title: Clients
 
     <div class="row clients-page">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/trinitymirror.png" class="img-responsive hover-effect bordered" alt="">
+        <img src="/assets/img/custom/home/clients/trinitymirror.png" class="img-responsive bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>Trinity Mirror</h3>
@@ -200,7 +200,7 @@ title: Clients
 
     <div class="row clients-page" style="border-bottom: 0px">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/findmypast.jpg" class="img-responsive hover-effect bordered" alt="">
+        <img src="/assets/img/custom/home/clients/findmypast.jpg" class="img-responsive bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>Findmypast</h3>
@@ -223,7 +223,7 @@ title: Clients
 
     <div class="row clients-page">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/skillsmatter.jpg" class="img-responsive hover-effect bordered" alt="">
+        <img src="/assets/img/custom/home/clients/skillsmatter.jpg" class="img-responsive bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>Skills Matter</h3>
@@ -236,7 +236,7 @@ title: Clients
 
     <div class="row clients-page">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/jetbrainsLogo.png" class="img-responsive hover-effect bordered" alt="">
+        <img src="/assets/img/custom/home/clients/jetbrainsLogo.png" class="img-responsive bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>Jetbrains</h3>
@@ -249,7 +249,7 @@ title: Clients
 
     <div class="row clients-page" style="border-bottom: 0px">
       <div class="col-md-2">
-        <img src="/assets/img/custom/home/clients/github.png" class="img-responsive hover-effect bordered" alt="">
+        <img src="/assets/img/custom/home/clients/github.png" class="img-responsive bordered" alt="">
       </div>
       <div class="col-md-10">
         <h3>Github</h3>

--- a/company/index.html
+++ b/company/index.html
@@ -87,42 +87,42 @@ title: Company
 
 				<div class="row">
 					<div class="col-sm-6 col-md-4">
-						<div class="block-centered equalheight thumbnail-style">
+						<div class="block-centered equalheight">
 							<i class="icon-heart icon-color-red no-border"></i>
 							<h3>{% t company-how_we_work-software_craftsmanship.title  %}</h3>
 							<p>{% t company-how_we_work-software_craftsmanship.subtitle  %}</p>		            
 						</div>
 					</div>
 					<div class="col-md-4 col-sm-6">
-						<div class="block-centered equalheight thumbnail-style">
+						<div class="block-centered equalheight">
 							<i class="icon-paper-plane icon-color-red no-border"></i>
 							<h3>{% t company-how_we_work-agile_and_lean.title %}</h3>
 							<p>{% t company-how_we_work-agile_and_lean.subtitle %}</p>
 						</div>
 					</div>
 					<div class="col-md-4 col-sm-6">
-						<div class="block-centered equalheight thumbnail-style">
+						<div class="block-centered equalheight">
 							<i class="icon-reload icon-color-red no-border"></i>
 							<h3>{% t company-how_we_work-continous_delivery.title %}</h3>
 							<p>{% t company-how_we_work-continous_delivery.subtitle %}</p>
 						</div>
 					</div>
 					<div class="col-md-4 col-sm-6">
-						<div class="block-centered equalheight thumbnail-style">
+						<div class="block-centered equalheight">
 							<i class="icon-control-forward icon-color-red no-border"></i>
 							<h3>{% t company-how_we_work-xp.title %}</h3>
 							<p>{% t company-how_we_work-xp.subtitle %}</p>
 						</div>
 					</div>
 					<div class="col-md-4 col-sm-6">
-						<div class="block-centered equalheight thumbnail-style">
+						<div class="block-centered equalheight">
 							<i class="icon-settings icon-color-red no-border"></i>
 							<h3>{% t company-how_we_work-devops.title %}</h3>
 							<p>{% t company-how_we_work-devops.subtitle %}</p>
 						</div>
 					</div>
 					<div class="col-md-4 col-sm-6">
-						<div class="block-centered equalheight thumbnail-style">
+						<div class="block-centered equalheight">
 							<i class="icon-screen-desktop icon-color-red no-border"></i>
 							<h3>{% t company-how_we_work-technology.title %}</h3>
 							<p>{% t company-how_we_work-technology.subtitle %}</p>			        

--- a/index.html
+++ b/index.html
@@ -165,37 +165,37 @@ layout: default
         </div>
 		<div class="row">
 		    <div class="col-sm-4 col-md-2">
-		        <div class="block-centered block-centered-condensed equalheight thumbnail-style bg-white">
+		        <div class="block-centered block-centered-condensed equalheight bg-white">
                     <i class="icon-custom icon-md icon-color-red icon-heart no-border"></i>
 		    <h3>{% t index-how_we_work.value1_title %}</h3>
 		        </div>
 		    </div>
 		    <div class="col-sm-4 col-md-2">
-		        <div class="block-centered block-centered-condensed equalheight thumbnail-style bg-white">
+		        <div class="block-centered block-centered-condensed equalheight bg-white">
 		            <i class="icon-custom icon-md icon-color-red icon-paper-plane no-border"></i>
 		            <h3>{% t index-how_we_work.value2_title %}</h3>
 		        </div>
 		    </div>
 		    <div class="col-sm-4 col-md-2">
-		        <div class="block-centered block-centered-condensed equalheight thumbnail-style bg-white">
+		        <div class="block-centered block-centered-condensed equalheight bg-white">
 		            <i class="icon-custom icon-md icon-color-red icon-reload no-border"></i>
 		            <h3>{% t index-how_we_work.value3_title %}</h3>
 		        </div>
 		    </div>
 			<div class="col-sm-4 col-md-2">
-			    <div class="block-centered block-centered-condensed equalheight thumbnail-style bg-white">
+			    <div class="block-centered block-centered-condensed equalheight bg-white">
                     <i class="icon-custom icon-md icon-color-red icon-control-forward no-border"></i>
                     <h3>{% t index-how_we_work.value4_title %}</h3>
 			    </div>
 			</div>
 			<div class="col-sm-4 col-md-2">
-			    <div class="block-centered block-centered-condensed equalheight thumbnail-style bg-white">
+			    <div class="block-centered block-centered-condensed equalheight bg-white">
                     <i class="icon-custom icon-md icon-color-red icon-settings no-border"></i>
                     <h3>{% t index-how_we_work.value5_title %}</h3>
 			    </div>
 			</div>
 		    <div class="col-sm-4 col-md-2">
-		        <div class="block-centered block-centered-condensed equalheight thumbnail-style bg-white">
+		        <div class="block-centered block-centered-condensed equalheight bg-white">
 		            <i class="icon-custom icon-md icon-color-red icon-screen-desktop no-border"></i>
 		            <h3>{% t index-how_we_work.value6_title %}</h3>
 		        </div>


### PR DESCRIPTION
This PR removes the hover effect on items which are actually not actionable:
- Clients logo
- How We Work in the landing page
- How We Work in the Company page
