### PR TITLE
Put language selector on top right in desktop mode (solves #405)

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -5,7 +5,23 @@
 			<img class="logo-header" src="/assets/img/codurance.png" alt="Codurance Logo" height="45px;">
 		</a>
 		<!-- End Logo -->
-
+    <div class="topbar pull-right language-selector">
+      <ul class="loginbar">
+        <li>
+          <i class="fa fa-globe"></i>
+          {% for lang in site.languages %}
+          {% if lang == site.lang %}
+          <span class="language"><strong>{{ lang }}</strong></span>
+          {% else %}
+          <a href="{{ site.domains[lang] }}{{ page.url }}">{{ lang }}</a>
+          {% endif %}
+          {% if forloop.last == false  %}
+          <span class="separator"> | </span>
+          {% endif  %}
+          {% endfor %}
+        </li>
+      </ul>
+    </div>
 		<!-- Toggle get grouped for better mobile display -->
 		<button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse">
 			<span class="sr-only">Toggle navigation</span>
@@ -23,23 +39,11 @@
 				<li><a href="/events">{% t sections.events %}</a></li>
 				<li><a href="/company">{% t sections.company %}</a></li>
 				<li><a href="/careers">{% t sections.careers %}</a></li>
-				<div class="topbar pull-right">
-					<ul class="loginbar">
-						<li>
-							<i class="fa fa-globe"></i>
-							{% for lang in site.languages %}
-							{% if lang == site.lang %}
-							<span class="language"><strong>{{ lang }}</strong></span>
-							{% else %}
-							<a href="{{ site.domains[lang] }}{{ page.url }}">{{ lang }}</a>
-							{% endif %}
-							{% if forloop.last == false  %}
-							<span class="separator"> | </span>
-							{% endif  %}
-							{% endfor %}
-						</li>
-					</ul>
-				</div>
+        {% for lang in site.languages %}
+        {% if lang != site.lang %}
+        <li class="language-link-in-menu"><a href="{{ site.domains[lang] }}{{ page.url }}"><i class="fa fa-globe"></i>&nbsp;{{ lang }}</a></li>
+        {% endif %}
+        {% endfor %}
 			</ul>
 		</div><!--/end container-->
 	</div><!--/navbar-collapse-->

--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -41,6 +41,18 @@ body.header-fixed-space-default {
 	.header .topbar ul.loginbar > li {
 		padding-right: 20px;
 	}
+  .language-selector {
+    display: none;
+  }
+  .language-link-in-menu {
+    display: block !important;
+  }
+}
+
+@media (min-width: 992px) {
+  .language-link-in-menu {
+    display: none !important;
+  }
 }
 
 .header .topbar ul.loginbar {
@@ -92,6 +104,11 @@ body.header-fixed-space-default {
 	min-width: 100px;
 	position: absolute;
 	background: #f0f0f0;
+}
+
+.language-selector {
+  margin-top: 0.5em;
+  margin-right: 1.5em;
 }
 
 .header .topbar li:hover ul.languages {

--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -168,7 +168,6 @@ body.header-fixed-space-default {
 	z-index: 99;
 	background: #fff;
 	position: relative;
-	border-bottom: solid 2px #eee;
 }
 
 /*Header Container*/
@@ -296,7 +295,7 @@ body.header-fixed-space-default {
     }
 
     .header .navbar-nav {
-        margin: 0 0 5px;
+        margin: 0px;
         float: none !important;
     }
 


### PR DESCRIPTION
Desktop look (both languages are shown):

![image](https://cloud.githubusercontent.com/assets/1684420/19161014/12e51328-8bea-11e6-9aaa-bd570f831224.png)

Mobile look (the current language is not shown, each language is a different section in the menu):

![image](https://cloud.githubusercontent.com/assets/1684420/19161003/073a6e88-8bea-11e6-8210-0869571cb0e8.png)
