### PR TITLE
Python script to list tags and count of articles

### DIFF
--- a/list-tags.py
+++ b/list-tags.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+import pip, sys
+ 
+def require(*packages):
+    for package in packages:
+        try:
+            if not isinstance(package, str):
+                import_name, install_name = package
+            else:
+                import_name = install_name = package
+            __import__(import_name)
+        except ImportError:
+ 
+            cmd = ['install', install_name]
+            if not hasattr(sys, 'real_prefix'):
+                cmd.append('--user')
+            pip.main(cmd)
+ 
+require('PyYAML')
+
+import yaml
+from collections import defaultdict
+import os
+import operator
+import csv
+
+all_tags = defaultdict(int)
+
+for filename in os.listdir('_posts'):
+    with open("_posts/" + filename, 'r') as stream:
+	try:
+	    post_metadata = yaml.load_all(stream).next()
+	    if 'tags' in post_metadata:
+		for tag in post_metadata['tags']:
+		  all_tags[tag] = all_tags[tag] + 1
+	except yaml.YAMLError as exc:
+	    print(exc)
+
+all_tags_sorted = sorted(all_tags.items(), key=operator.itemgetter(1))
+
+csv_out = csv.writer(sys.stdout)
+for tag_with_count in all_tags_sorted:
+  csv_out.writerow(tag_with_count)


### PR DESCRIPTION
When writing a blog post, it is hard to know which tags are already on the website. So we all make up a bunch of tags, but then the site ends up with more than 150 tags that only apply to one article, which does not help the reader navigate articles.

This Python script auto-imports the required pyaml library and then lists all the tags in the `_posts` folder, along with the number of tagged articles, sorted in ascending order of articles count.

The goal is for writers to be able to pick already used tags when writing an article.

Example output:

```
jira,1
virtual machine,1
Agile,1
oss,1
rest,1
kafka,1
Web API,1
concurrency,1
build system,1
akka-http,1
coordination,1
cli,1
async,1
personal,1
Ubiquitous-language,1
AWS,1
user stories,1
terminal,1
reactive,1
opensource,1
saxon,1
publish-subscribe,1
cloud-services,1
Continuous-Deployment,1
server side,1
data modeling,1
Cucumber,1
csharp,1
test-doubles,1
F#,1
synchronization,1
cqrs,1
Separation of concerns,1
dreams,1
continuous-integration,1
open-source,1
xquery,1
screencast,1
Kata,1
security,1
Babun,1
functional programming,1
kernel,1
Continuous Deployment,1
Java,1
Scala,1
jade,1
sync,1
travis,1
Heroku,1
socrates-uk,1
Walking-Skeleton,1
expresiveness,1
event,1
Domain-Driven-Design,1
virtualisation,1
container,1
interaction-design,1
company-culture,1
Memento,1
Swift,1
ddd,1
TeamCity,1
sbt,1
workflow,1
amazon-web-services,1
javascript,1
scalability,1
efficiency,1
Team,1
open source,1
Security,1
standard,1
swift,1
DDD,1
FsCheck,1
hypervisor,1
correctness,1
incremental-design,1
Terraform,1
open-book management,1
Design,1
product owner,1
messaging,1
organisation,1
decision-making,1
lambda,1
codereview,1
managers,1
google-plus,1
vim,1
rpc,1
haskell,1
cross-platform,1
Kitura,1
tools,1
unit,1
scrum master,1
customisation,1
abstractions,1
C#,1
continuous delivery,1
UI design,1
teamwork,1
inflection-point,1
swagger,1
SOLID,1
Big-Data,1
retrospective,1
c#,1
failure,1
VIPER,1
oauth,1
the-software-craftsman,1
java8,1
apprentice,1
single responsibility,1
operating system,1
ux,1
SBT,1
Web service,1
iteration,1
windows,1
mouseless,1
ui,1
transparency,1
zsh,1
guide,1
NCrunch,1
open financials,1
prompt,1
streams,1
shortcuts,1
.NET,1
ms sql server,1
Mutual Authentication,1
supervision,1
Jenkins,1
outside-in,1
Bounded-context,1
sprint,1
cassandra,1
Travis,1
Amazon-Web-Services,1
deliberate-practice,1
Consolas,1
website-solution,1
event-sourcing,1
bare metal,1
actors,1
estimatation,1
howto,1
collaboration,1
philosophy,1
metrics,1
database,1
unit-test,1
HTTPS,1
Vapor,1
craftsmen,1
Continuous-Integration,1
classicist,1
framework,1
Resharper,1
fsm,1
cohesion,1
socrates,1
command,1
volumes,1
outdoor-retrospective,1
docker,1
Clean architecture,1
big data,2
iOS,2
domain-driven-design,2
Objective-C,2
.net,2
teams,2
threading,2
Learning,2
pair-programming,2
Visual-Studio,2
spring,2
naming,2
integration,2
state,2
streaming,2
maven,2
mentoring,2
anti-pattern,2
spark,2
git,2
scalatra,2
Docker,2
object-orientation-abusers,2
code-smells,2
mob-programming,2
performance,2
android,2
visual-studio,2
REST,2
coupling,2
inflection point,2
test-driven-development,2
change-preventers,2
OOP,2
mentorship,2
Cloud,2
distributed systems,3
refactoring,3
umbraco,3
cms,3
scala,3
cloud,3
career,3
user-story,3
clojure,3
community,3
clean-code,3
devops,3
culture,3
windows-azure,3
productivity,3
serverless,3
aws,3
automation,3
apprenticeship,3
github,3
team,4
software design,4
codurance-way,4
backlog,4
learning,4
practices,4
microservices,5
design-patterns,5
testing,5
scrum,5
TDD,5
akka,5
quality,6
functional-programming,6
architecture,7
codurance,8
agile,11
java,12
tdd,14
design,14
craftsmanship,37
```
