### PR TITLE
Make contact form use HTTPS (required for it to work)

### DIFF
--- a/company/index.html
+++ b/company/index.html
@@ -147,7 +147,7 @@ title: Company
 			<h3>{% t company-contact-form.title %}</h3>
                         <p>{% t company-contact-form.subtitle %}</p><br/>
                         <div class="row">
-                            <form class="sky-form" action="http://formspree.io/hello@codurance.com" method="POST">
+                            <form class="sky-form" action="https://formspree.io/hello@codurance.com" method="POST">
                                 <input type="hidden" name="_next" value="/aboutus/thanks"/>
                                 <input type="hidden" name="_subject" value="Codurance Contact"/>
                                 <div class="col-sm-6">


### PR DESCRIPTION
Currently our contact form does not work because the service provider (Formspree) requires to be called on HTTPS and we're using HTTP.
