### PR TITLE
Removed title from Transformation Priority Premise post 

### DIFF
--- a/_posts/2015-05-11-applying-transformation-priority-premise-to-roman-numerals-kata.md
+++ b/_posts/2015-05-11-applying-transformation-priority-premise-to-roman-numerals-kata.md
@@ -12,8 +12,6 @@ tags:
 - TDD
 - .net
 ---
-#Applying Transformation Priority Premise to Roman Numerals Kata
-
 > "As tests get more specific code gets more generic." - Uncle Bob
 
 ##TDD


### PR DESCRIPTION
Removing duplicate title from post: https://codurance.com/2015/05/18/applying-transformation-priority-premise-to-roman-numerals-kata/