### PR TITLE
Add S3 cloudfront support in every build

### DIFF
--- a/_utility/deploy_prb.sh
+++ b/_utility/deploy_prb.sh
@@ -28,6 +28,5 @@ fi
 
 echo "Synchronizing bucket: $BUCKET_NAME"
 aws s3 sync . s3://$BUCKET_NAME --acl public-read
-aws configure set preview.cloudfront true
 aws cloudfront create-invalidation --distribution-id EML2BUMD54HSC --paths "/*"
 

--- a/circle.yml
+++ b/circle.yml
@@ -15,6 +15,7 @@ dependencies:
     - gem install rspec-core -v '3.4.1'
     - gem install jekyll
     - sudo apt-get install jq
+    - aws configure set preview.cloudfront true
 checkout:
   post:
     - bundle install


### PR DESCRIPTION
CircleCI does not have cloudfront enabled by default, so we have to enable it explictly. 