### PR TITLE
Fix syntax warning while constructing the site

### DIFF
--- a/company/index.html
+++ b/company/index.html
@@ -76,7 +76,7 @@ title: Company
 					</div>
 				</div>
 			</div>
-		{% if numberOfElements == 6 || nbElementDisplayed == arraySize %}
+		{% if numberOfElements == 6 or nbElementDisplayed == arraySize %}
 		{% assign numberOfElements = 0 %}
 			</div>
 		{% endif %}


### PR DESCRIPTION
We were getting this error when building the site:
```bash rake buildboth
bundle exec jekyll build --trace
Configuration file: /home/panavtec/Code/Codurance/site/_config.yml
            Source: /home/panavtec/Code/Codurance/site
       Destination: /home/panavtec/Code/Codurance/site/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
Building site for default language: "en" to: /home/panavtec/Code/Codurance/site/_site
         AutoPages: Disabled/Not configured in site.config.
Loading translation from file /home/panavtec/Code/Codurance/site/_i18n/en.yml
        Pagination: Complete, processed 3 pagination page(s)
    Liquid Warning: Liquid syntax error (line 75): Expected end_of_string but found pipe in "numberOfElements == 6 || nbElementDisplayed == arraySize" in company/index.html
Building site for language: "es" to: /home/panavtec/Code/Codurance/site/_site/es
         AutoPages: Disabled/Not configured in site.config.
Loading translation from file /home/panavtec/Code/Codurance/site/_i18n/es.yml
        Pagination: Complete, processed 3 pagination page(s)
    Liquid Warning: Liquid syntax error (line 75): Expected end_of_string but found pipe in "numberOfElements == 6 || nbElementDisplayed == arraySize" in company/index.html
Build complete
                    done in 60.818 seconds.
 Auto-regeneration: disabled. Use --watch to enable.
```
It seems that `||` is not valid, we should use `or` instead

Source: https://github.com/jekyll/jekyll/issues/3594