### PR TITLE
Add missing resources which were required by JS and CSS

### DIFF
--- a/_includes/foot.html
+++ b/_includes/foot.html
@@ -3,6 +3,7 @@
 <script src="{{ "/assets/plugins/jquery/jquery-migrate.min.js" | prepend: site.baseurl }}" type="text/javascript"></script>
 <script src="{{ "/assets/plugins/bootstrap/js/bootstrap.min.js" | prepend: site.baseurl }}" type="text/javascript"></script>
 <script src="{{ "/assets/plugins/back-to-top.js" | prepend: site.baseurl }}" type="text/javascript"></script>
+<script src="{{ "/assets/plugins/jquery.parallax.js" | prepend: site.baseurl }}" type="text/javascript"></script>
 <!-- JS Implementing Plugins -->
 <script src="{{ "/assets/plugins/owl-carousel2/owl.carousel.min.js" | prepend: site.baseurl }}" type="text/javascript"></script>
 <script src="{{ "/assets/js/handlebars.js" | prepend: site.baseurl }}" type="text/javascript"></script>

--- a/assets/css/blocks.css
+++ b/assets/css/blocks.css
@@ -249,7 +249,7 @@
   overflow: hidden;
   padding: 10px 0 6px;
   border-bottom: solid 1px #eee;
-  background: url(../img/patterns/breadcrumbs.png) repeat;
+  background: url(../img/gbreadcrumbs.png) repeat;
 }
 
 .video-business-img1 {

--- a/assets/css/blocks.css
+++ b/assets/css/blocks.css
@@ -249,7 +249,7 @@
   overflow: hidden;
   padding: 10px 0 6px;
   border-bottom: solid 1px #eee;
-  background: url(../img/gbreadcrumbs.png) repeat;
+  background: url(../img/breadcrumbs.png) repeat;
 }
 
 .video-business-img1 {


### PR DESCRIPTION
Problems:
1. When the page is initiated we always try to apply parallax effect on the specific elements, but the required plugin was never loaded and all pages we had the error from JS:
```
Uncaught TypeError: jQuery(...).parallax is not a function
    at app.js:270
    at dispatch (jquery.min.js:4)
    at r.handle (jquery.min.js:4)
```

2. On the case study pages, we use breadcrumbs CSS elements which require the specific image. In the CSS stylesheet, we have the wrong path to this image and web browsers reports missing resource.
