### PR TITLE
New Craftsman Page

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -31,6 +31,10 @@ task :serve do
   sh 'bundle exec jekyll serve --config _config.yml,_config_en.yml --watch --trace --port 4000 --host 0.0.0.0'
 end
 
+task :servees do
+  sh 'bundle exec jekyll serve --config _config.yml,_config_es.yml --watch --trace --port 4000 --host 0.0.0.0'
+end
+
 task :servequick do
   sh 'bundle exec jekyll serve --config _config.yml,_config_en.yml --watch --incremental --limit_posts 3 --port 4000 --host 0.0.0.0'
 end

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -317,12 +317,6 @@ careers:
      life_apprentice:
        title: The Life of an Apprentice
        description: Want to get a feel of what life as an apprentice is like? These blogs from our current and recent apprentices will show you what you can expect when you begin your journey with us.
-       first_week_title: "First week at Codurance:"
-       first_week_description:
-       first_year_title: "My first year at Codurance:"
-       first_year_description:
-       learning_specification_title: "Learning specification by example:"
-       learning_specification_description:
 careers-how_we_grow:
    title: How we grow?
    description: <p>Our people are our company and our product—our company grows as our people grow. The culture of learning is ingrained into our very core. Our fortnightly catchups are focused around learning from each other, and we run many internal sessions to build technologies expertise and hone our skills. We encourage and support each other to write blogs, record videos, organise community sessions, and present at conferences.</p>

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -279,25 +279,25 @@ careers:
      description: Our product is our people. We firmly belive that your job and associated benefits should allow you to flourish both personally and professionally. 
      learning_title: Learning and Development
      conf_title: Conferences
-     conf_description: 5 days of conference budget per year, including T&L and tickets, covered by us. We’ll pay for you as well, so need need to use holiday days.
+     conf_description: 5 days of conference budget per year, including T&L and tickets, covered by us. We’ll pay for you as well, so no need to use your holiday days.
      training_title: Training 
-     training_description: Unlimited training budget! So long as the course is relevant for the company and you'll do a lightening talk on the subject, we’re happy to pay for it.
+     training_description: No fixed training budget. So long as the course is relevant for the company and you'll do a lightning talk on the subject, we’re happy to pay for it.
      books_title: Books
-     books_description: Found something interesting to read that doesn’t already live in our office or digital library? We’ll cover book expenses - and ask to read it after you as well!.
+     books_description: Found something interesting to read that doesn’t already live in our office or digital library? We’ll cover book expenses - and ask to read it after you as well!
      culture_title: Culture
      experts_title: Internal Community of Experts
-     experts_description: Whether at client projects, our intenal and external events, you’ll be working alongside Craftsman that share your passion for learning.
+     experts_description: You’ll be working alongside Craftsman that share your passion for learning, whether that’s on a client project or contributing to our internal projects.
      transparency_title: Transparency
      transparency_description: All of our salaries and finances are available to everyone from day one. Nothing to hide here.  
      autonomy_title: Autonomy
-     autonomy_description: Got an idea? Form a circle, take ownership, run with it and deliver it.
+     autonomy_description: Got an idea? Form an Initiative Circle, take ownership, run with it and see it through to delivery.
      lifestyle_title: Lifestyle
-     holidays_title: Holidays
-     holidays_description: Pretty standard stuff. 28 days per year.
+     holidays_title: Holidays & Flexibility
+     holidays_description: We offer 22 holiday days (increasing to 25 over time), in addition to national holidays. We’re also flexible with how our people manage their time. Need to work from home? No problem.
      pensions_title: Pensions & Income Protection
-     pensions_description: All covered, as standard. Incidentally, many of these came from Initiatve Circles in our early days (see above).
+     pensions_description: All covered, as standard. Incidentally, many of these came from Initiative Circles in our early days (see above).
      life_cover_title: Life Cover & Private Medical
-     life_cover_description: Lumpsum payment for life cover, and Dental cashback scheme for you and your children.
+     life_cover_description: A ‘Lump Sum’ payment for life cover, and Dental cashback scheme for you and your children.
      mentor_title: Mentor
      mentor_description: You will choose a mentor, who will guide you throughout your apprenticeship.
    become_an_apprentice:

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -347,10 +347,12 @@ careers-become_a_craftsman:
    description: <p>You have a strong desire to build quality software, to constantly improve yourself, and to help others to do the same. You have a broad appreciation for technology, with a deep knowledge of either <strong>Java</strong>, <strong>.NET</strong> or <strong>Node.js</strong> stacks.</p>
    link_title: Apply
    apply_title: I'm interested
+   more_info: Read the full description
 careers-become_an_apprentice:
    title: Become an Apprentice
    description: <p>Aspiring to become a Software Craftsmen, you’re ready to start your journey of education under the guidance of your mentor.</p>
    link_title: Apply
+   more_info: Read the full description
 careers-hiring_process:
    title: Hiring process
    description: <p>We aim to keep our hiring process as straightforward and transparent as possible.</p>

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -262,19 +262,43 @@ careers:
    title: Come work with us
    email: join-us@codurance.com
    become_a_craftsman:
-     join_title: Joining Codurance
+     title: Become a Craftsman / Craftswoman
+     apply_title: Apply 
+     get_in_touch: More qeustions? Get in touch
      join_description: We are a company formed by craftswomen and craftsmen who care about the quality of the work we do and also who we do it with. We are always looking for the talented people who share our passion for writing well-crafted code and believe in the principles and values of Software Craftmanship, Exreme Programming and Agile software development. For us, mastering a strong set of technical practices is as important as our understanding of different technology stacks we use. <br> Due to the nature of the work we do - working closely with our clients and their technical teams - good communication skills, willingness to learn and work with different technology stacks, fully embrace Extreme Programming practices and Agile methodologies, and confidence to express ideas are essential to join our team.
      practices_title: Practices
-     practices_description: You have good experience with Extreme Programming practices (Specially TDD and CI), DevOps (experience setting up build pipelines and automation (Continuous Deployment)), and a good understanding of different Agile practices and how they can help a team to work effectively.
+     practices_description: We are practitioners of Agile/Lean processes and Extreme Programming Practices, specifically TDD, CI, and Simple Design. We prefer to work in a DevOps culture and value Continuous Deployment/Delivery. We love automation, and value the tools that allow us to automate. We know how to work in an Agile team and can help mentor teams to adopt these processes and practices. 
      design_title: Design and Architecture
-     design_description: You have a good appreciation for software design at micro and macro level, including familirtity with SOLID principles and DDD (Domain Driven Design). You naturally follow Clean Code principles (have you read the book?). You also have some understanding of different types of architecture including layered and hexagonal architectures, microservices, CQRS, and Event Sourcing. You understand the basics principles of security, logging, monitoring, and supportin projects in production.
-     technology_stacks_title: Technology stacks
-     technology_stacks_description: Although we are always exploring different technologies, currently, the three main technology stacks we use are JVM (Java/Clojure/Scala), Net (C#/F#), and NodeJS. Most of our projects use amazon AWS or Azure as a cloud solution. We expect a solid experience in at least one of the languages we use and familiarity with cloud solutions.
+     design_description: Our Craftsmen have a great appreciation of Software Design both at macro and micro levels. We naturally follow Clean Code principles. We understand architectural concerns relating to performance, security, logging, monitoring, and operations. We know the major architectural patterns including Microservices, Hexagonal, Event Sourcing, and CQRS - and their suitability to particular scenarios. 
+     technology_stacks_title: Technology platforms 
+     technology_stacks_description: Although we are always exploring different technologies, currently, the three main technology platforms we use are JVM (Java, Clojure, Scala), .Net (C#, F#), and NodeJS. Most of our projects use amazon AWS or Azure as a cloud solution. We expect a solid experience in at least one of the languages we use and familiarity with cloud solutions. We expect our Craftsmen to have a good grasp of front-end technologies based on HTML, CSS, and Javascript. 
      personality_title: Personality
-     personality_description: Due to the nature of our work (we are a consultancy company and we work directly with our clients in all our projects), it is important that you have good communication skills and like working as part of a team. You are able to present your opinions and ideas in a clear, collaborative, respectfull and effective manner. You havea strong desire to build well-crafted software, constantly improve yourself, and to help others do the same. You are constantly learning and can describe all the different ways you achieve that. You consider yourself a technologist and is always keen to explore and work with different technologies. You don\'t shy away form leadership roles and are comfortable to lead by example.
-     hiring_title: Hiring process
-     hiring_description: Pellentesque dapibus suscipit ligula.  Donec posuere augue in quam.  Etiam vel tortor sodales tellus ultricies commodo.  Suspendisse potenti.  Aenean in sem ac leo mollis blandit.  Donec neque quam, dignissim in, mollis nec, sagittis eu, wisi.  Phasellus lacus.  Etiam laoreet quam sed arcu.  Phasellus at dui in ligula mollis ultricies.  Integer placerat tristique nisl.  Praesent augue.  Fusce commodo.  Vestibulum convallis, lorem a tempus semper, dui dui euismod elit, vitae placerat urna tortor vitae lacus.  Nullam libero mauris, consequat quis, varius et, dictum id, arcu.  Mauris mollis tincidunt felis.  Aliquam feugiat tellus ut neque.  Nulla facilisis, risus a rhoncus fermentum, tellus tellus lacinia purus, et dictum nunc justo sit amet elit.
-     benefits_title: What you'll get
+     personality_description: Good communication skills essential to our work. We need to be able to present our opinions and ideas in a clear, collaborative, respectful and effective manner. We have strong desire to build well-crafted software, constantly improve ourselves, and to help others do the same. We are constantly learning and apply many different approaches to our learning. We  lead by example and we are always keen to explore and work with different technologies. 
+     benefits:
+       title: What you'll get
+       description: Our product is our people. We firmly belive that your job and associated benefits should allow you to flourish both personally and professionally. 
+       learning_title: Learning and Development
+       conf_title: Conferences
+       conf_description: 5 days of conference budget per year, including T&L and tickets, covered by us. We’ll pay for you as well, so need need to use holiday days.
+       training_title: Training 
+       training_description: Unlimited training budget! So long as the course is relevant for the company and you'll do a lightening talk on the subject, we’re happy to pay for it.
+       books_title: Books
+       books_description: Found something interesting to read that doesn’t already live in our office or digital library? We’ll cover book expenses - and ask to read it after you as well!.
+       culture_title: Culture
+       experts_title: Internal Community of Experts
+       experts_description: Whether at client projects, our intenal and external events, you’ll be working alongside Craftsman that share your passion for learning.
+       transparency_title: Transparency
+       transparency_description: All of our salaries and finances are available to everyone from day one. Nothing to hide here.  
+       autonomy_title: Autonomy
+       autonomy_description: Got an idea? Form a circle, take ownership, run with it and deliver it.
+       lifestyle_title: Lifestyle
+       holidays_title: Holidays
+       holidays_description: Pretty standard stuff. 28 days per year.
+       pensions_title: Pensions & Income Protection
+       pensions_description: All covered, as standard. Incidentally, many of these came from Initiatve Circles in our early days (see above).
+       life_cover_title: Life Cover & Private Medical
+       life_cover_description: Lumpsum payment for life cover, and Dental cashback scheme for you and your children.
+       
 careers-how_we_grow:
    title: How we grow?
    description: <p>Our people are our company and our product—our company grows as our people grow. The culture of learning is ingrained into our very core. Our fortnightly catchups are focused around learning from each other, and we run many internal sessions to build technologies expertise and hone our skills. We encourage and support each other to write blogs, record videos, organise community sessions, and present at conferences.</p>

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -263,7 +263,7 @@ careers:
    email: join-us@codurance.com
    become_a_craftsman:
      title: Become a Craftsman / Craftswoman
-     apply_title: Apply 
+     apply_title: Become a Craftsman 
      get_in_touch: More qeustions? Get in touch
      join_description: We are a company formed by craftswomen and craftsmen who care about the quality of the work we do and also who we do it with. We are always looking for the talented people who share our passion for writing well-crafted code and believe in the principles and values of Software Craftmanship, Exreme Programming and Agile software development. For us, mastering a strong set of technical practices is as important as our understanding of different technology stacks we use. <br> Due to the nature of the work we do - working closely with our clients and their technical teams - good communication skills, willingness to learn and work with different technology stacks, fully embrace Extreme Programming practices and Agile methodologies, and confidence to express ideas are essential to join our team.
      practices_title: Practices

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -298,7 +298,31 @@ careers:
        pensions_description: All covered, as standard. Incidentally, many of these came from Initiatve Circles in our early days (see above).
        life_cover_title: Life Cover & Private Medical
        life_cover_description: Lumpsum payment for life cover, and Dental cashback scheme for you and your children.
-       
+   become_an_apprentice:
+     title: Apprenticeship program
+     apply_title: Become an Apprentice
+     description: Apprentices share our passion for creating well-crafted software, but have not yet had the suitable learning opportunities to refine their craft.
+     how_works_title: How does it work?
+     how_works_description:
+       You will be asked to choose a mentor, a Software Craftsman that will coach & guide you throughout your apprenticeship. Your focus will be on self-improvement, honing your technical skills and practices by working on internal projects, as well as person projects and Katas. 
+       <p> 
+       <p>The priority is for you to acquire the basic set of skills necessary to become recognised, as software craftsman, by the rest of the company. We regularly send our apprentices to training courses.
+     background_title: What background do I need to have?
+     background_description:
+       At this level, we will expect that you are a productive developer in the language of your choice on the JVM, .NET, and/or Node JS platforms. You know of Agile processes and practices and can apply them and are looking to become an expert in reasoning about them. You have basic knowledge of micro level and macro level design. 
+      <p> 
+      <p>You have at least narrow experience of tools and technology, sufficient according to your current experience. You can communicate your ideas in a team setting and want to develop skills to convince others to your thinking. You have a strong desire to learn and hone your skills as an effective software developer. You like to teach as well as to learn.
+     is_it_for_me_title: Is this the programme for me?
+     is_it_for_me_description: If you are looking for a structured learning programme, complete with certifications, learning modules and regular training courses, then this isn’t the programme for you. If you are looking however for an intense education on what it means to be a Software Craftsmen, under the guidance of a mentor, learning the real-world technologies, practices and skills needed along the way, then we look forward to receiving your application.
+     life_apprentice:
+       title: The Life of an Apprentice
+       description: Want to get a feel of what life as an apprentice is like? These blogs from our current and recent apprentices will show you what you can expect when you begin your journey with us.
+       first_week_title: "First week at Codurance:"
+       first_week_description:
+       first_year_title: "My first year at Codurance:"
+       first_year_description:
+       learning_specification_title: "Learning specification by example:"
+       learning_specification_description:
 careers-how_we_grow:
    title: How we grow?
    description: <p>Our people are our company and our product—our company grows as our people grow. The culture of learning is ingrained into our very core. Our fortnightly catchups are focused around learning from each other, and we run many internal sessions to build technologies expertise and hone our skills. We encourage and support each other to write blogs, record videos, organise community sessions, and present at conferences.</p>

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -274,46 +274,44 @@ careers:
      technology_stacks_description: Although we are always exploring different technologies, currently, the three main technology platforms we use are JVM (Java, Clojure, Scala), .Net (C#, F#), and NodeJS. Most of our projects use amazon AWS or Azure as a cloud solution. We expect a solid experience in at least one of the languages we use and familiarity with cloud solutions. We expect our Craftsmen to have a good grasp of front-end technologies based on HTML, CSS, and Javascript. 
      personality_title: Personality
      personality_description: Good communication skills essential to our work. We need to be able to present our opinions and ideas in a clear, collaborative, respectful and effective manner. We have strong desire to build well-crafted software, constantly improve ourselves, and to help others do the same. We are constantly learning and apply many different approaches to our learning. We  lead by example and we are always keen to explore and work with different technologies. 
-     benefits:
-       title: What you'll get
-       description: Our product is our people. We firmly belive that your job and associated benefits should allow you to flourish both personally and professionally. 
-       learning_title: Learning and Development
-       conf_title: Conferences
-       conf_description: 5 days of conference budget per year, including T&L and tickets, covered by us. We’ll pay for you as well, so need need to use holiday days.
-       training_title: Training 
-       training_description: Unlimited training budget! So long as the course is relevant for the company and you'll do a lightening talk on the subject, we’re happy to pay for it.
-       books_title: Books
-       books_description: Found something interesting to read that doesn’t already live in our office or digital library? We’ll cover book expenses - and ask to read it after you as well!.
-       culture_title: Culture
-       experts_title: Internal Community of Experts
-       experts_description: Whether at client projects, our intenal and external events, you’ll be working alongside Craftsman that share your passion for learning.
-       transparency_title: Transparency
-       transparency_description: All of our salaries and finances are available to everyone from day one. Nothing to hide here.  
-       autonomy_title: Autonomy
-       autonomy_description: Got an idea? Form a circle, take ownership, run with it and deliver it.
-       lifestyle_title: Lifestyle
-       holidays_title: Holidays
-       holidays_description: Pretty standard stuff. 28 days per year.
-       pensions_title: Pensions & Income Protection
-       pensions_description: All covered, as standard. Incidentally, many of these came from Initiatve Circles in our early days (see above).
-       life_cover_title: Life Cover & Private Medical
-       life_cover_description: Lumpsum payment for life cover, and Dental cashback scheme for you and your children.
+   benefits:
+     title: What you'll get
+     description: Our product is our people. We firmly belive that your job and associated benefits should allow you to flourish both personally and professionally. 
+     learning_title: Learning and Development
+     conf_title: Conferences
+     conf_description: 5 days of conference budget per year, including T&L and tickets, covered by us. We’ll pay for you as well, so need need to use holiday days.
+     training_title: Training 
+     training_description: Unlimited training budget! So long as the course is relevant for the company and you'll do a lightening talk on the subject, we’re happy to pay for it.
+     books_title: Books
+     books_description: Found something interesting to read that doesn’t already live in our office or digital library? We’ll cover book expenses - and ask to read it after you as well!.
+     culture_title: Culture
+     experts_title: Internal Community of Experts
+     experts_description: Whether at client projects, our intenal and external events, you’ll be working alongside Craftsman that share your passion for learning.
+     transparency_title: Transparency
+     transparency_description: All of our salaries and finances are available to everyone from day one. Nothing to hide here.  
+     autonomy_title: Autonomy
+     autonomy_description: Got an idea? Form a circle, take ownership, run with it and deliver it.
+     lifestyle_title: Lifestyle
+     holidays_title: Holidays
+     holidays_description: Pretty standard stuff. 28 days per year.
+     pensions_title: Pensions & Income Protection
+     pensions_description: All covered, as standard. Incidentally, many of these came from Initiatve Circles in our early days (see above).
+     life_cover_title: Life Cover & Private Medical
+     life_cover_description: Lumpsum payment for life cover, and Dental cashback scheme for you and your children.
+     mentor_title: Mentor
+     mentor_description: You will choose a mentor, who will guide you through your apprenticeship
    become_an_apprentice:
      title: Apprenticeship program
      apply_title: Become an Apprentice
      description: Apprentices share our passion for creating well-crafted software, but have not yet had the suitable learning opportunities to refine their craft.
      how_works_title: How does it work?
-     how_works_description:
-       You will be asked to choose a mentor, a Software Craftsman that will coach & guide you throughout your apprenticeship. Your focus will be on self-improvement, honing your technical skills and practices by working on internal projects, as well as person projects and Katas. 
-       <p> 
-       <p>The priority is for you to acquire the basic set of skills necessary to become recognised, as software craftsman, by the rest of the company. We regularly send our apprentices to training courses.
+     how_works_description: The priority is for you to acquire the basic set of skills necessary to become recognised, as Software Craftsman, by the rest of the company. You will choose a mentor from our craftsmen who will help understand your strengths and weaknesses based on the core skill sets needed. 
      background_title: What background do I need to have?
-     background_description:
-       At this level, we will expect that you are a productive developer in the language of your choice on the JVM, .NET, and/or Node JS platforms. You know of Agile processes and practices and can apply them and are looking to become an expert in reasoning about them. You have basic knowledge of micro level and macro level design. 
-      <p> 
-      <p>You have at least narrow experience of tools and technology, sufficient according to your current experience. You can communicate your ideas in a team setting and want to develop skills to convince others to your thinking. You have a strong desire to learn and hone your skills as an effective software developer. You like to teach as well as to learn.
+     background_description: You are a productive developer in the language of your choice on the JVM, .NET, and/or Node JS platforms. You know of Agile processes and practices and can apply them and are looking to become an expert in reasoning about them. You have basic knowledge of micro level and macro level design.
      is_it_for_me_title: Is this the programme for me?
-     is_it_for_me_description: If you are looking for a structured learning programme, complete with certifications, learning modules and regular training courses, then this isn’t the programme for you. If you are looking however for an intense education on what it means to be a Software Craftsmen, under the guidance of a mentor, learning the real-world technologies, practices and skills needed along the way, then we look forward to receiving your application.
+     is_it_for_me_description: If you have a passion for learning and are ready for a chance to learn technologies and practices needed to become a Software Craftsman, under the guidance of a dedicated mentor, then we look forward to receiving your application.
+     how_long_title: How long does it last
+     how_long_description: Your mentor will guide you through your apprenticeship which we expect to be a maximum of 6 months. There is no exam in the end - when your mentor is convinced and can convince at least 3 other craftsmen, then you graduate.
      life_apprentice:
        title: The Life of an Apprentice
        description: Want to get a feel of what life as an apprentice is like? These blogs from our current and recent apprentices will show you what you can expect when you begin your journey with us.

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -299,11 +299,11 @@ careers:
      life_cover_title: Life Cover & Private Medical
      life_cover_description: Lumpsum payment for life cover, and Dental cashback scheme for you and your children.
      mentor_title: Mentor
-     mentor_description: You will choose a mentor, who will guide you through your apprenticeship
+     mentor_description: You will choose a mentor, who will guide you throughout your apprenticeship.
    become_an_apprentice:
      title: Apprenticeship program
      apply_title: Become an Apprentice
-     description: Apprentices share our passion for creating well-crafted software, but have not yet had the suitable learning opportunities to refine their craft.
+     description: Our apprentices share our passion for creating well-crafted software, but have not yet had the suitable learning opportunities to refine their craft.
      how_works_title: How does it work?
      how_works_description: The priority is for you to acquire the basic set of skills necessary to become recognised, as Software Craftsman, by the rest of the company. You will choose a mentor from our craftsmen who will help understand your strengths and weaknesses based on the core skill sets needed. 
      background_title: What background do I need to have?
@@ -311,7 +311,7 @@ careers:
      is_it_for_me_title: Is this the programme for me?
      is_it_for_me_description: If you have a passion for learning and are ready for a chance to learn technologies and practices needed to become a Software Craftsman, under the guidance of a dedicated mentor, then we look forward to receiving your application.
      how_long_title: How long does it last
-     how_long_description: Your mentor will guide you through your apprenticeship which we expect to be a maximum of 6 months. There is no exam in the end - when your mentor is convinced and can convince at least 3 other craftsmen, then you graduate.
+     how_long_description: Your mentor will guide you through your apprenticeship which we expect to be a maximum of 6 months. There is no formal exam at the end - when your mentor is convinced that you are ready, and can convince at least 3 other craftsmen as well, then you graduate.
      life_apprentice:
        title: The Life of an Apprentice
        description: Want to get a feel of what life as an apprentice is like? These blogs from our current and recent apprentices will show you what you can expect when you begin your journey with us.

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -273,26 +273,53 @@ careers:
      personality_description: Due to the nature of our work (we are a consultancy company and we work directly with our clients in all our projects), it is important that you have good communication skills and like working as part of a team. You are able to present your opinions and ideas in a clear, collaborative, respectfull and effective manner. You havea strong desire to build well-crafted software, constantly improve yourself, and to help others do the same. You are constantly learning and can describe all the different ways you achieve that. You consider yourself a technologist and is always keen to explore and work with different technologies. You don\'t shy away form leadership roles and are comfortable to lead by example.
      hiring_title: Hiring process
      hiring_description: Pellentesque dapibus suscipit ligula.  Donec posuere augue in quam.  Etiam vel tortor sodales tellus ultricies commodo.  Suspendisse potenti.  Aenean in sem ac leo mollis blandit.  Donec neque quam, dignissim in, mollis nec, sagittis eu, wisi.  Phasellus lacus.  Etiam laoreet quam sed arcu.  Phasellus at dui in ligula mollis ultricies.  Integer placerat tristique nisl.  Praesent augue.  Fusce commodo.  Vestibulum convallis, lorem a tempus semper, dui dui euismod elit, vitae placerat urna tortor vitae lacus.  Nullam libero mauris, consequat quis, varius et, dictum id, arcu.  Mauris mollis tincidunt felis.  Aliquam feugiat tellus ut neque.  Nulla facilisis, risus a rhoncus fermentum, tellus tellus lacinia purus, et dictum nunc justo sit amet elit.
-     benefits_title: What you'll get
-     become_an_apprentice:
-       title: Apprenticeship program
-       apply_title: Become an Apprentice
-       description: Apprentices share our passion for creating well-crafted software, but have not yet had the suitable learning opportunities to refine their craft.
-       how_works_title: How does it work?
-       how_works_description:
+   benefits:
+     title: What you'll get
+     description: Our product is our people. We firmly belive that your job and associated benefits should allow you to flourish both personally and professionally. 
+     learning_title: Learning and Development
+     conf_title: Conferences
+     conf_description: 5 days of conference budget per year, including T&L and tickets, covered by us. We’ll pay for you as well, so need need to use holiday days.
+     training_title: Training 
+     training_description: Unlimited training budget! So long as the course is relevant for the company and you'll do a lightening talk on the subject, we’re happy to pay for it.
+     books_title: Books
+     books_description: Found something interesting to read that doesn’t already live in our office or digital library? We’ll cover book expenses - and ask to read it after you as well!.
+     culture_title: Culture
+     experts_title: Internal Community of Experts
+     experts_description: Whether at client projects, our intenal and external events, you’ll be working alongside Craftsman that share your passion for learning.
+     transparency_title: Transparency
+     transparency_description: All of our salaries and finances are available to everyone from day one. Nothing to hide here.  
+     autonomy_title: Autonomy
+     autonomy_description: Got an idea? Form a circle, take ownership, run with it and deliver it.
+     lifestyle_title: Lifestyle
+     holidays_title: Holidays
+     holidays_description: Pretty standard stuff. 28 days per year.
+     pensions_title: Pensions & Income Protection
+     pensions_description: All covered, as standard. Incidentally, many of these came from Initiatve Circles in our early days (see above).
+     life_cover_title: Life Cover & Private Medical
+     life_cover_description: Lumpsum payment for life cover, and Dental cashback scheme for you and your children.
+     mentor_title: Mentor
+     mentor_description: You will choose a mentor, who will guide you through your apprenticeship
+   become_an_apprentice:
+     title: Programa de Aprendizaje
+     apply_title: Conviertete en un aprendiz
+     description: Apprentices share our passion for creating well-crafted software, but have not yet had the suitable learning opportunities to refine their craft.
+     how_works_title: How does it work?
+     how_works_description:
          You will be asked to choose a mentor, a Software Craftsman that will coach & guide you throughout your apprenticeship. Your focus will be on self-improvement, honing your technical skills and practices by working on internal projects, as well as person projects and Katas. 
          <p> 
          <p>The priority is for you to acquire the basic set of skills necessary to become recognised, as software craftsman, by the rest of the company. We regularly send our apprentices to training courses.
-       background_title: What background do I need to have?
-       background_description:
+     background_title: What background do I need to have?
+     background_description:
            At this level, we will expect that you are a productive developer in the language of your choice on the JVM, .NET, and/or Node JS platforms. You know of Agile processes and practices and can apply them and are looking to become an expert in reasoning about them. You have basic knowledge of micro level and macro level design. 
            <p> 
            <p>You have at least narrow experience of tools and technology, sufficient according to your current experience. You can communicate your ideas in a team setting and want to develop skills to convince others to your thinking. You have a strong desire to learn and hone your skills as an effective software developer. You like to teach as well as to learn.
-       is_it_for_me_title: Is this the programme for me?
-       is_it_for_me_description: If you are looking for a structured learning programme, complete with certifications, learning modules and regular training courses, then this isn’t the programme for you. If you are looking however for an intense education on what it means to be a Software Craftsmen, under the guidance of a mentor, learning the real-world technologies, practices and skills needed along the way, then we look forward to receiving your application.
-       life_apprentice:
-         title: The Life of an Apprentice
-         description: Want to get a feel of what life as an apprentice is like? These blogs from our current and recent apprentices will show you what you can expect when you begin your journey with us.
+     is_it_for_me_title: Is this the programme for me?
+     is_it_for_me_description: If you are looking for a structured learning programme, complete with certifications, learning modules and regular training courses, then this isn’t the programme for you. If you are looking however for an intense education on what it means to be a Software Craftsmen, under the guidance of a mentor, learning the real-world technologies, practices and skills needed along the way, then we look forward to receiving your application.
+     how_long_title: How long does it last
+     how_long_description: Your mentor will guide you through your apprenticeship which we expect to be a maximum of 6 months. There is no exam in the end - when your mentor is convinced and can convince at least 3 other craftsmen, then you graduate.
+     life_apprentice:
+       title: La vida del Aprendiz.
+       description: Want to get a feel of what life as an apprentice is like? These blogs from our current and recent apprentices will show you what you can expect when you begin your journey with us.
 careers-how_we_grow:
    title: Cómo crecemos?
    description: <p>Nuestra gente es nuestra empresa y nuestro producto, nuestra empresa crece como crece nuestra gente. La cultura de aprendizaje está arraigada a nuestra esencia. Nuestros encuentros quincenales se centran en torno al aprendizaje de los demás, en ellos realizamos muchas sesiones internas para compartir experiencias tecnológicas y perfeccionar nuestras habilidades. Nos alentamos y apoyamos unos a otros para escribir blogs, grabar vídeos, organizar sesiones en la comunidad y para presentar en conferencias.</p>

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -320,10 +320,12 @@ careers-become_a_craftsman:
    description: <p>Tienes un firme deseo de hacer software de calidad, de mejorar continuamente, y de ayudar a los demás a hacer lo mismo. Tienes una amplia apreciación por la tecnología, con un profundo conocimiento de Java, .NET o Node.js.</p>
    link_title: Aplicar 
    apply_title: Estoy interesado
+   more_info: Lee la descripción completa
 careers-become_an_apprentice:
    title: Conviértete en Aprendiz
    description: <p>Aspiras a convertirte en un Artesano de Software, estás listo para emprender tu viaje de aprendizaje bajo la guía de tu mentor.</p>
    link_title: Aplicar
+   more_info: Lee la descripción completa
 careers-hiring_process:
    title: Proceso de contratación 
    description: <p>Nuestro proceso de selección tiene entre 3 y 5 pasos, dependiendo del candidato:</p>

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -274,6 +274,25 @@ careers:
      hiring_title: Hiring process
      hiring_description: Pellentesque dapibus suscipit ligula.  Donec posuere augue in quam.  Etiam vel tortor sodales tellus ultricies commodo.  Suspendisse potenti.  Aenean in sem ac leo mollis blandit.  Donec neque quam, dignissim in, mollis nec, sagittis eu, wisi.  Phasellus lacus.  Etiam laoreet quam sed arcu.  Phasellus at dui in ligula mollis ultricies.  Integer placerat tristique nisl.  Praesent augue.  Fusce commodo.  Vestibulum convallis, lorem a tempus semper, dui dui euismod elit, vitae placerat urna tortor vitae lacus.  Nullam libero mauris, consequat quis, varius et, dictum id, arcu.  Mauris mollis tincidunt felis.  Aliquam feugiat tellus ut neque.  Nulla facilisis, risus a rhoncus fermentum, tellus tellus lacinia purus, et dictum nunc justo sit amet elit.
      benefits_title: What you'll get
+     become_an_apprentice:
+       title: Apprenticeship program
+       apply_title: Become an Apprentice
+       description: Apprentices share our passion for creating well-crafted software, but have not yet had the suitable learning opportunities to refine their craft.
+       how_works_title: How does it work?
+       how_works_description:
+         You will be asked to choose a mentor, a Software Craftsman that will coach & guide you throughout your apprenticeship. Your focus will be on self-improvement, honing your technical skills and practices by working on internal projects, as well as person projects and Katas. 
+         <p> 
+         <p>The priority is for you to acquire the basic set of skills necessary to become recognised, as software craftsman, by the rest of the company. We regularly send our apprentices to training courses.
+       background_title: What background do I need to have?
+       background_description:
+           At this level, we will expect that you are a productive developer in the language of your choice on the JVM, .NET, and/or Node JS platforms. You know of Agile processes and practices and can apply them and are looking to become an expert in reasoning about them. You have basic knowledge of micro level and macro level design. 
+           <p> 
+           <p>You have at least narrow experience of tools and technology, sufficient according to your current experience. You can communicate your ideas in a team setting and want to develop skills to convince others to your thinking. You have a strong desire to learn and hone your skills as an effective software developer. You like to teach as well as to learn.
+       is_it_for_me_title: Is this the programme for me?
+       is_it_for_me_description: If you are looking for a structured learning programme, complete with certifications, learning modules and regular training courses, then this isn’t the programme for you. If you are looking however for an intense education on what it means to be a Software Craftsmen, under the guidance of a mentor, learning the real-world technologies, practices and skills needed along the way, then we look forward to receiving your application.
+       life_apprentice:
+         title: The Life of an Apprentice
+         description: Want to get a feel of what life as an apprentice is like? These blogs from our current and recent apprentices will show you what you can expect when you begin your journey with us.
 careers-how_we_grow:
    title: Cómo crecemos?
    description: <p>Nuestra gente es nuestra empresa y nuestro producto, nuestra empresa crece como crece nuestra gente. La cultura de aprendizaje está arraigada a nuestra esencia. Nuestros encuentros quincenales se centran en torno al aprendizaje de los demás, en ellos realizamos muchas sesiones internas para compartir experiencias tecnológicas y perfeccionar nuestras habilidades. Nos alentamos y apoyamos unos a otros para escribir blogs, grabar vídeos, organizar sesiones en la comunidad y para presentar en conferencias.</p>

--- a/_includes/apply_form.html
+++ b/_includes/apply_form.html
@@ -8,34 +8,86 @@
               </div>
               <div class="modal-body">
                   <div id="{{ include.target }}-fields">
-                    <div class="row">
-
-                        <div class="col-md-12">
-                            <p><label>Name</label><input name="{{ include.target }}-name" class="form-control" type="text" /></p>
-                            <p><label>Email</label><input name="{{ include.target }}-email" class="form-control" type="text" /></p>
-                            <p><label>Tell us about yourself</label><textarea name="{{ include.target }}-message" class="form-control" rows="10" id="message"></textarea>   </p>
-                        </div>
-                    </div>
-                    <div class="row"><div class="col-md-12">
+                      <div class="row">
+                            <div class="col-md-6 margin-bottom-20">
+                                <label>First Name</label><input name="{{ include.target }}-firstname" class="form-control" type="text" />
+                            </div>
+                            <div class="col-md-6">
+                                <label>Last Name</label><input name="{{ include.target }}-lastname" class="form-control" type="text" />
+                            </div>
+                      </div>
+                      <div class="row">
+                              <div class="col-md-6 margin-bottom-20">
+                                  <label>Email</label><input name="{{ include.target }}-email" class="form-control" type="text" />
+                              </div>
+                              <div class="col-md-6">
+                                  <label>Phone Number</label><input name="{{ include.target }}-phone" class="form-control" type="text" />
+                              </div>
+                      </div>
+                      <div class="row bg-color-light">
+                              <div class="col-md-6 margin-bottom-20">
+                                  <label>GitHub Account</label><input name="{{ include.target }}-github" class="form-control" type="text" />
+                              </div>
+                              <div class="col-md-6">
+                                  <label>Linkedin Account</label><input name="{{ include.target }}-linkedin" class="form-control" type="text" />
+                          </div>
+                      </div>
+                      <div class="row bg-color-light">
+                              <div class="col-md-6 margin-bottom-20">
+                                  <label>StackOverFlow Account</label><input name="{{ include.target }}-stackoverflow" class="form-control" type="text" />
+                              </div>
+                              <div class="col-md-6">
+                                  <label>Blog</label><input name="{{ include.target }}-blog" class="form-control" type="text" />
+                              </div>
+                      </div>
+                      <div class ="row">
+                          <div class="col-md-12 margin-bottom-20">
+                          <label>Where do you want to work?</label>
+                          <select name="{{ include.target }}-location" class="form-control" id="location">
+                              <option value="London">London</option>
+                              <option value="Barcelona">Barcelona</option>
+                          </select>
+                          </div>
+                      </div>
+                      <div class ="row">
+                          <div class="col-md-12 margin-bottom-20">
+                          <label>What does Software Craftmanship mean to you?</label>
+                          <textarea name="{{ include.target }}-craftmanship" class="form-control" rows="10" id="craftmanship"></textarea>
+                          </div>
+                      </div>
+                      <div class ="row">
+                          <div class="col-md-12 margin-bottom-20">
+                          <label>Tell us about yourself (technologies that you have used, projects you have worked on)</label>
+                          <textarea name="{{ include.target }}-message" class="form-control" rows="10" id="message"></textarea>
+                          </div>
+                      </div>
+                  </div>
+                  <div class="row">
+                      <div class="col-md-12 ">
                           <div id="input-error-msg-{{ include.target }}" class="alert alert-danger fade in hide">
                               <strong>Please: </strong> enter all the requested fields.
                           </div>
-                    </div></div>
-                    <div class="row"><div class="col-md-12">
+                      </div>
+                  </div>
+                  <div class="row">
+                      <div class="col-md-12 margin-bottom-20">
                           <div id="error-msg-{{ include.target }}" class="alert alert-danger fade in hide">
                               <strong>Ops something went wrong: </strong> please try later or email us at <a href="mailto:hello@codurance.com">hello@codurance.com</a>.
                           </div>
-                    </div></div>
+                      </div>
                   </div>
-                  <div>
-                    <div id="success-msg-{{include.target}}" class="alert alert-success fade in hide">
-                              <strong>Thank you: </strong> we will be in touch with you shortly.
-                          </div>
+                  <div class="row">
+                      <div class="col-md-12 margin-bottom-20">
+                      <div id="success-msg-{{include.target}}" class="alert alert-success fade in hide">
+                          <strong>Thank you: </strong> we will be in touch with you shortly.
+                      </div>
+                      </div>
                   </div>
               </div>
               <div class="modal-footer">
                   <button type="button" class="btn-u btn-u-default" data-dismiss="modal">Close</button>
-                  <button id="{{ include.target }}-apply-btn" type="button" class="btn-u btn-u-primary" onclick="submitApplication('{{ include.title }}', '{{ include.target }}');" >Apply</button>
+                  <button id="{{ include.target }}-apply-btn" type="button" class="btn-u btn-u-primary"
+                          onclick="submitApplication('{{ include.title }}', '{{ include.target }}');" >Apply</button>
               </div>
           </div>
       </div>

--- a/_includes/apply_form.html
+++ b/_includes/apply_form.html
@@ -1,96 +1,96 @@
 <form action="#" id="sky-form2" class="sky-form">  
-<div class="modal fade" id="{{ include.target }}-form" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-      <div class="modal-dialog">
-          <div class="modal-content">
-              <div class="modal-header">
-                  <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                  <h4 class="modal-title" id="myModalLabel4">{{ include.title }}</h4>
-              </div>
-              <div class="modal-body">
-                  <div id="{{ include.target }}-fields">
-                      <div class="row">
+    <div class="modal fade" id="{{ include.target }}-form" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title" id="myModalLabel4">{{ include.title }}</h4>
+                </div>
+                <div class="modal-body">
+                    <div id="{{ include.target }}-fields">
+                        <div class="row">
                             <div class="col-md-6 margin-bottom-20">
                                 <label>First Name</label><input name="{{ include.target }}-firstname" class="form-control" type="text" />
                             </div>
                             <div class="col-md-6">
                                 <label>Last Name</label><input name="{{ include.target }}-lastname" class="form-control" type="text" />
                             </div>
-                      </div>
-                      <div class="row">
-                              <div class="col-md-6 margin-bottom-20">
-                                  <label>Email</label><input name="{{ include.target }}-email" class="form-control" type="text" />
-                              </div>
-                              <div class="col-md-6">
-                                  <label>Phone Number</label><input name="{{ include.target }}-phone" class="form-control" type="text" />
-                              </div>
-                      </div>
-                      <div class="row bg-color-light">
-                              <div class="col-md-6 margin-bottom-20">
-                                  <label>GitHub Account</label><input name="{{ include.target }}-github" class="form-control" type="text" />
-                              </div>
-                              <div class="col-md-6">
-                                  <label>Linkedin Account</label><input name="{{ include.target }}-linkedin" class="form-control" type="text" />
-                          </div>
-                      </div>
-                      <div class="row bg-color-light">
-                              <div class="col-md-6 margin-bottom-20">
-                                  <label>StackOverFlow Account</label><input name="{{ include.target }}-stackoverflow" class="form-control" type="text" />
-                              </div>
-                              <div class="col-md-6">
-                                  <label>Blog</label><input name="{{ include.target }}-blog" class="form-control" type="text" />
-                              </div>
-                      </div>
-                      <div class ="row">
-                          <div class="col-md-12 margin-bottom-20">
-                          <label>Where do you want to work?</label>
-                          <select name="{{ include.target }}-location" class="form-control" id="location">
-                              <option value="London">London</option>
-                              <option value="Barcelona">Barcelona</option>
-                          </select>
-                          </div>
-                      </div>
-                      <div class ="row">
-                          <div class="col-md-12 margin-bottom-20">
-                          <label>What does Software Craftmanship mean to you?</label>
-                          <textarea name="{{ include.target }}-craftmanship" class="form-control" rows="10" id="craftmanship"></textarea>
-                          </div>
-                      </div>
-                      <div class ="row">
-                          <div class="col-md-12 margin-bottom-20">
-                          <label>Tell us about yourself (technologies that you have used, projects you have worked on)</label>
-                          <textarea name="{{ include.target }}-message" class="form-control" rows="10" id="message"></textarea>
-                          </div>
-                      </div>
-                  </div>
-                  <div class="row">
-                      <div class="col-md-12 ">
-                          <div id="input-error-msg-{{ include.target }}" class="alert alert-danger fade in hide">
-                              <strong>Please: </strong> enter all the requested fields.
-                          </div>
-                      </div>
-                  </div>
-                  <div class="row">
-                      <div class="col-md-12 margin-bottom-20">
-                          <div id="error-msg-{{ include.target }}" class="alert alert-danger fade in hide">
-                              <strong>Ops something went wrong: </strong> please try later or email us at <a href="mailto:hello@codurance.com">hello@codurance.com</a>.
-                          </div>
-                      </div>
-                  </div>
-                  <div class="row">
-                      <div class="col-md-12 margin-bottom-20">
-                      <div id="success-msg-{{include.target}}" class="alert alert-success fade in hide">
-                          <strong>Thank you: </strong> we will be in touch with you shortly.
-                      </div>
-                      </div>
-                  </div>
-              </div>
-              <div class="modal-footer">
-                  <button type="button" class="btn-u btn-u-default" data-dismiss="modal">Close</button>
-                  <button id="{{ include.target }}-apply-btn" type="button" class="btn-u btn-u-primary"
-                          onclick="submitApplication('{{ include.title }}', '{{ include.target }}');" >Apply</button>
-              </div>
-          </div>
-      </div>
-  </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-6 margin-bottom-20">
+                                <label>Email</label><input name="{{ include.target }}-email" class="form-control" type="text" />
+                            </div>
+                            <div class="col-md-6">
+                                <label>Phone Number</label><input name="{{ include.target }}-phone" class="form-control" type="text" />
+                            </div>
+                        </div>
+                        <div class="row bg-color-light">
+                            <div class="col-md-6 margin-bottom-20">
+                                <label>GitHub Account</label><input name="{{ include.target }}-github" class="form-control" type="text" />
+                            </div>
+                            <div class="col-md-6">
+                                <label>Linkedin Account</label><input name="{{ include.target }}-linkedin" class="form-control" type="text" />
+                            </div>
+                        </div>
+                        <div class="row bg-color-light">
+                            <div class="col-md-6 margin-bottom-20">
+                                <label>StackOverFlow Account</label><input name="{{ include.target }}-stackoverflow" class="form-control" type="text" />
+                            </div>
+                            <div class="col-md-6">
+                                <label>Blog</label><input name="{{ include.target }}-blog" class="form-control" type="text" />
+                            </div>
+                        </div>
+                        <div class ="row">
+                            <div class="col-md-12 margin-bottom-20">
+                                <label>Where do you want to work?</label>
+                                <select name="{{ include.target }}-location" class="form-control" id="location">
+                                    <option value="London">London</option>
+                                    <option value="Barcelona">Barcelona</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class ="row">
+                            <div class="col-md-12 margin-bottom-20">
+                                <label>What does Software Craftmanship mean to you?</label>
+                                <textarea name="{{ include.target }}-craftmanship" class="form-control" rows="10" id="craftmanship"></textarea>
+                            </div>
+                        </div>
+                        <div class ="row">
+                            <div class="col-md-12 margin-bottom-20">
+                                <label>Tell us about yourself (technologies that you have used, projects you have worked on)</label>
+                                <textarea name="{{ include.target }}-message" class="form-control" rows="10" id="message"></textarea>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-12 ">
+                            <div id="input-error-msg-{{ include.target }}" class="alert alert-danger fade in hide">
+                                <strong>Please: </strong> enter all the requested fields.
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-12 margin-bottom-20">
+                            <div id="error-msg-{{ include.target }}" class="alert alert-danger fade in hide">
+                                <strong>Ops something went wrong: </strong> please try later or email us at <a href="mailto:hello@codurance.com">hello@codurance.com</a>.
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-12 margin-bottom-20">
+                            <div id="success-msg-{{include.target}}" class="alert alert-success fade in hide">
+                                <strong>Thank you: </strong> we will be in touch with you shortly.
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn-u btn-u-default" data-dismiss="modal">Close</button>
+                    <button id="{{ include.target }}-apply-btn" type="button" class="btn-u btn-u-primary"
+                            onclick="submitApplication('{{ include.title }}', '{{ include.target }}');" >Apply</button>
+                </div>
+            </div>
+        </div>
+    </div>
 </form>
 

--- a/_includes/life_of_apprentice_articles.html
+++ b/_includes/life_of_apprentice_articles.html
@@ -1,0 +1,20 @@
+{% assign post = include.param[0] %}
+{% assign title = post.title | truncatewords: include.truncated %}
+{% assign date = post.date %}
+{% assign author = post.author %}
+{% assign imgSrc = post.image.src %}
+{% assign postUrl = post.url | prepend: site.baseUrl %}
+{% assign abstract = post.content | strip_html | truncatewords:30 %}
+
+<div class="col-md-4 md-margin-bottom-40">
+    <div class="blog-box homepage-blog-thumb">
+        <img class="img-responsive bordered" alt="{{ title }}" src={{ imgSrc }}>
+        <h3><a href={{ postUrl }}>{{ title }}</a></h3>
+        <p>{{ abstract }}</p>
+        <ul class="list-inline blog-box-info">
+            <li>{% t publications-post.author_title %} {{ author | author_links }} </li>
+            <li>|</li>
+            <li><i class="fa fa-clock-o"></i> {{ date | date_to_string }}</li>
+        </ul>
+    </div>
+</div>

--- a/_includes/life_of_apprentice_articles.html
+++ b/_includes/life_of_apprentice_articles.html
@@ -1,16 +1,18 @@
 {% assign post = include.param[0] %}
-{% assign title = post.title | truncatewords: include.truncated %}
+{% assign title = post.title | truncatewords: include.truncated_title %}
 {% assign date = post.date %}
 {% assign author = post.author %}
 {% assign imgSrc = post.image.src %}
 {% assign postUrl = post.url | prepend: site.baseUrl %}
-{% assign abstract = post.content | strip_html | truncatewords:30 %}
+{% assign abstract = post.content | strip_html | truncatewords:include.truncated_abstract %}
 
 <div class="col-md-4 md-margin-bottom-40">
     <div class="blog-box homepage-blog-thumb">
         <img class="img-responsive bordered" alt="{{ title }}" src={{ imgSrc }}>
-        <h3><a href={{ postUrl }}>{{ title }}</a></h3>
-        <p>{{ abstract }}</p>
+        <div class="blog-content">
+            <h3><a href={{ postUrl }}>{{ title }}</a></h3>
+            <p>{{ abstract }}</p>
+        </div>
         <ul class="list-inline blog-box-info">
             <li>{% t publications-post.author_title %} {{ author | author_links }} </li>
             <li>|</li>

--- a/careers/become_a_craftsman.html
+++ b/careers/become_a_craftsman.html
@@ -4,192 +4,199 @@ title: Become a Craftsman
 
 ---
 <div class="breadcrumbs-v3 ourpeople">
-    <div class="container text-center">
-    </div>
+	<div class="container text-center">
+	</div>
 </div>
 
 
-		<div class="bg-color-light">
-			<div class="container content-md">
-				<div class="text-center margin-bottom-60">
-					<div class="row">
-						<div class="col-md-12">
-							<div class="col-md-offset-3 col-md-6 margin-top-10">
-								<h2 class="title-v2 title-center">{% t careers-become_a_craftsman.title %}</h2>
-							</div>
-							<div class="col-md-3">
-								<button class="btn btn-u btn-more" data-toggle="modal" data-target="#craftsman-form">{% t careers-become_a_craftsman.apply_title %}</button>
-							</div>
-						</div>
+<div class="bg-color-light">
+	<div class="container content-md">
+		<div class="text-center margin-bottom-60">
+			<div class="row">
+				<div class="col-md-12">
+					<div class="col-md-offset-3 col-md-6 margin-top-10">
+						<h2 class="title-v2 title-center">{% t careers-become_a_craftsman.title %}</h2>
 					</div>
-
-					{% include apply_form.html title="Become a Craftsman" target="craftsman" %}
-
-					<p class="space-lg-hor">Our craftsmen are practitioners, teachers, mentors, and leaders. We will assess your expertise in the following areas to see if you are a fit for us, this will also help you understand if we are a fit for you.</p>
-				</div>
-
-				<div class="row margin-bottom-30">
-					<div class="col-sm-6 sm-margin-bottom-50 animated fadeIn wow" data-wow-duration="1.5s">
-						<div class="service-block-v8">
-							<i class="icon-bubbles"></i>
-							<div class="service-block-desc">
-								<h3> {% t careers.become_a_craftsman.practices_title %} </h3>
-								<p> {% t careers.become_a_craftsman.practices_description %}</p>
-							</div>
-						</div>
-					</div>
-					<div class="col-sm-6 sm-margin-bottom-20 animated fadeIn wow" data-wow-duration="1.5s" data-wow-delay=".3s">
-						<div class="service-block-v8">
-							<i class="icon-globe"></i>
-							<div class="service-block-desc">
-								<h3> {% t careers.become_a_craftsman.design_title %} </h3>
-								<p> {% t careers.become_a_craftsman.design_description %} </p>
-							</div>
-						</div>
+					<div class="col-md-3">
+						<button class="btn btn-u btn-more" data-toggle="modal" data-target="#craftsman-form">{% t careers-become_a_craftsman.apply_title %}</button>
 					</div>
 				</div>
-				<div class="row margin-bottom-30">
-					<div class="col-sm-6 sm-margin-bottom-50 animated fadeIn wow" data-wow-duration="1.5s">
-						<div class="service-block-v8">
-							<i class="icon-bubbles"></i>
-							<div class="service-block-desc">
-								<h3> {% t careers.become_a_craftsman.technology_stacks_title %} </h3>
-								<p> {% t careers.become_a_craftsman.technology_stacks_description %}</p>
-							</div>
-						</div>
+			</div>
+
+			{% include apply_form.html title="Become a Craftsman" target="craftsman" %}
+
+			<p class="space-lg-hor">Our craftsmen are practitioners, teachers, mentors, and leaders. We will assess your expertise in the following areas to see if you are a fit for us, this will also help you understand if we are a fit for you.</p>
+		</div>
+
+		<div class="row margin-bottom-30">
+			<div class="col-sm-6 sm-margin-bottom-50 animated fadeIn wow" data-wow-duration="1.5s">
+				<div class="service-block-v8">
+					<i class="icon-bubbles"></i>
+					<div class="service-block-desc">
+						<h3> {% t careers.become_a_craftsman.practices_title %} </h3>
+						<p> {% t careers.become_a_craftsman.practices_description %}</p>
 					</div>
-					<div class="col-sm-6 sm-margin-bottom-20 animated fadeIn wow" data-wow-duration="1.5s" data-wow-delay=".3s">
-						<div class="service-block-v8">
-							<i class="icon-globe"></i>
-							<div class="service-block-desc">
-								<h3> {% t careers.become_a_craftsman.personality_title %} </h3>
-								<p> {% t careers.become_a_craftsman.personality_description %} </p>
-							</div>
-						</div>
+				</div>
+			</div>
+			<div class="col-sm-6 sm-margin-bottom-20 animated fadeIn wow" data-wow-duration="1.5s" data-wow-delay=".3s">
+				<div class="service-block-v8">
+					<i class="icon-globe"></i>
+					<div class="service-block-desc">
+						<h3> {% t careers.become_a_craftsman.design_title %} </h3>
+						<p> {% t careers.become_a_craftsman.design_description %} </p>
 					</div>
 				</div>
 			</div>
 		</div>
+		<div class="row margin-bottom-30">
+			<div class="col-sm-6 sm-margin-bottom-50 animated fadeIn wow" data-wow-duration="1.5s">
+				<div class="service-block-v8">
+					<i class="icon-bubbles"></i>
+					<div class="service-block-desc">
+						<h3> {% t careers.become_a_craftsman.technology_stacks_title %} </h3>
+						<p> {% t careers.become_a_craftsman.technology_stacks_description %}</p>
+					</div>
+				</div>
+			</div>
+			<div class="col-sm-6 sm-margin-bottom-20 animated fadeIn wow" data-wow-duration="1.5s" data-wow-delay=".3s">
+				<div class="service-block-v8">
+					<i class="icon-globe"></i>
+					<div class="service-block-desc">
+						<h3> {% t careers.become_a_craftsman.personality_title %} </h3>
+						<p> {% t careers.become_a_craftsman.personality_description %} </p>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
 
-    <div>
-      <div class="container content-md">
+<div>
+	<div class="container content-md">
 
-        <h2 class="title-v2 title-center">{% t careers.become_a_craftsman.benefits.title %}</h2>
-        <p class="space-lg-hor">{% t careers.become_a_craftsman.benefits.description %}</p>
+		<h2 class="title-v2 title-center">{% t careers.become_a_craftsman.benefits.title %}</h2>
+		<p class="space-lg-hor">{% t careers.become_a_craftsman.benefits.description %}</p>
 
-        <div class="row">
-            <div class="heading heading-v4">
-              <h3>{% t careers.become_a_craftsman.benefits.learning_title%}</h3> 
-            </div>
-        </div>
-
-
-        <div> 
-          <div class="row content-boxes-v3 margin-bottom-20 margin-top-20">
-            <div class="col-sm-4 sm-margin-bottom-40">
-              <i class="icon-custom rounded-x icon-sm icon-bg-u fa fa-lightbulb-o"></i>
-              <div class="content-boxes-in-v3">
-                <h2 class="heading-sm">
-                  <span>{% t careers.become_a_craftsman.benefits.conf_title%}</span>
-                </h2>
-                <p>{% t careers.become_a_craftsman.benefits.conf_description %}</p>
-              </div>
-            </div>
-            <div class="col-sm-4 sm-margin-bottom-40 bg-grey">
-              <i class="icon-custom rounded-x icon-sm icon-bg-blue fa fa-bullhorn"></i>
-              <div class="content-boxes-in-v3">
-                <h2 class="heading-sm">
-                  <span>{% t careers.become_a_craftsman.benefits.training_title%}</span>
-                </h2>
-                <p>{% t careers.become_a_craftsman.benefits.training_description %}</p>
-              </div>
-            </div>
-            <div class="col-sm-4">
-              <i class="icon-custom rounded-x icon-sm icon-bg-red icon-line icon-rocket"></i>
-              <div class="content-boxes-in-v3">
-                <h2 class="heading-sm">
-                  <span>{% t careers.become_a_craftsman.benefits.books_title %}</span>
-                </h2>
-                <p>{% t careers.become_a_craftsman.benefits.books_description %}</p>
-              </div>
-            </div>
-          </div>
+		<div class="row">
+			<div class="heading heading-v4">
+				<h3>{% t careers.become_a_craftsman.benefits.learning_title%}</h3> 
+			</div>
+		</div>
 
 
-          <div class="row">
-            <div class="heading heading-v4">
-              <h3>{% t careers.become_a_craftsman.benefits.culture_title %}</h3> 
-            </div>
-          </div>
-
-          <div class="row content-boxes-v3 margin-bottom-20 margin-top-20">
-            <div class="col-sm-4 sm-margin-bottom-40">
-              <i class="icon-custom rounded-x icon-sm icon-color-u fa fa-lightbulb-o"></i>
-              <div class="content-boxes-in-v3">
-                <h2 class="heading-sm">
-                  <span>{% t careers.become_a_craftsman.benefits.experts_title %}</span>
-                </h2>
-                <p>{% t careers.become_a_craftsman.benefits.experts_description %}</p>
-              </div>
-            </div>
-            <div class="col-sm-4 sm-margin-bottom-40 bg-grey">
-              <i class="icon-custom rounded-x icon-sm icon-color-blue fa fa-bullhorn"></i>
-              <div class="content-boxes-in-v3">
-                <h2 class="heading-sm">
-                  <span>{% t careers.become_a_craftsman.benefits.transparency_title %}</span>
-                </h2>
-                <p>{% t careers.become_a_craftsman.benefits.transparency_description %}</p>
-              </div>
-            </div>
-            <div class="col-sm-4">
-              <i class="icon-custom rounded-x icon-sm icon-color-red icon-line icon-rocket"></i>
-              <div class="content-boxes-in-v3">
-                <h2 class="heading-sm">
-                  <span>{% t careers.become_a_craftsman.benefits.autonomy_title %}</span>
-                </h2>
-                <p>{% t careers.become_a_craftsman.benefits.autonomy_description %}</p>
-              </div>
-            </div>
-          </div>
+		<div> 
+			<div class="row content-boxes-v3 margin-bottom-20 margin-top-20">
+				<div class="col-sm-4 sm-margin-bottom-40">
+					<i class="icon-custom rounded-x icon-sm icon-bg-u fa fa-lightbulb-o"></i>
+					<div class="content-boxes-in-v3">
+						<h2 class="heading-sm">
+							<span>{% t careers.become_a_craftsman.benefits.conf_title%}</span>
+						</h2>
+						<p>{% t careers.become_a_craftsman.benefits.conf_description %}</p>
+					</div>
+				</div>
+				<div class="col-sm-4 sm-margin-bottom-40 bg-grey">
+					<i class="icon-custom rounded-x icon-sm icon-bg-blue fa fa-bullhorn"></i>
+					<div class="content-boxes-in-v3">
+						<h2 class="heading-sm">
+							<span>{% t careers.become_a_craftsman.benefits.training_title%}</span>
+						</h2>
+						<p>{% t careers.become_a_craftsman.benefits.training_description %}</p>
+					</div>
+				</div>
+				<div class="col-sm-4">
+					<i class="icon-custom rounded-x icon-sm icon-bg-red icon-line icon-rocket"></i>
+					<div class="content-boxes-in-v3">
+						<h2 class="heading-sm">
+							<span>{% t careers.become_a_craftsman.benefits.books_title %}</span>
+						</h2>
+						<p>{% t careers.become_a_craftsman.benefits.books_description %}</p>
+					</div>
+				</div>
+			</div>
 
 
-          <div class="row">
-            <div class="heading heading-v4">
-              <h3>{% t careers.become_a_craftsman.benefits.lifestyle_title %}</h3> 
-            </div>
-          </div>
+			<div class="row">
+				<div class="heading heading-v4">
+					<h3>{% t careers.become_a_craftsman.benefits.culture_title %}</h3> 
+				</div>
+			</div>
 
-          <div class="row content-boxes-v3 margin-bottom-40 margin-top-20">
-            <div class="col-sm-4 sm-margin-bottom-40">
-              <i class="icon-custom rounded-x icon-sm icon-color-u fa fa-lightbulb-o"></i>
-              <div class="content-boxes-in-v3">
-                <h2 class="heading-sm">
-                  <span>{% t careers.become_a_craftsman.benefits.holidays_title %}</span>
-                </h2>
-                <p>{% t careers.become_a_craftsman.benefits.holidays_description %}</p>
-              </div>
-            </div>
-            <div class="col-sm-4 sm-margin-bottom-40 bg-grey">
-              <i class="icon-custom rounded-x icon-sm icon-color-blue fa fa-bullhorn"></i>
-              <div class="content-boxes-in-v3">
-                <h2 class="heading-sm">
-                  <span>{% t careers.become_a_craftsman.benefits.pensions_title %}</span>
-                </h2>
-                <p>{% t careers.become_a_craftsman.benefits.pensions_description %}</p>
-              </div>
-            </div>
-            <div class="col-sm-4">
-              <i class="icon-custom rounded-x icon-sm icon-color-red icon-line icon-rocket"></i>
-              <div class="content-boxes-in-v3">
-                <h2 class="heading-sm">
-                  <span>{% t careers.become_a_craftsman.benefits.life_cover_title %}</span>
-                </h2>
-                <p>{% t careers.become_a_craftsman.benefits.life_cover_description %}</p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    </div>
-  </div>
+			<div class="row content-boxes-v3 margin-bottom-20 margin-top-20">
+				<div class="col-sm-4 sm-margin-bottom-40">
+					<i class="icon-custom rounded-x icon-sm icon-color-u fa fa-lightbulb-o"></i>
+					<div class="content-boxes-in-v3">
+						<h2 class="heading-sm">
+							<span>{% t careers.become_a_craftsman.benefits.experts_title %}</span>
+						</h2>
+						<p>{% t careers.become_a_craftsman.benefits.experts_description %}</p>
+					</div>
+				</div>
+				<div class="col-sm-4 sm-margin-bottom-40 bg-grey">
+					<i class="icon-custom rounded-x icon-sm icon-color-blue fa fa-bullhorn"></i>
+					<div class="content-boxes-in-v3">
+						<h2 class="heading-sm">
+							<span>{% t careers.become_a_craftsman.benefits.transparency_title %}</span>
+						</h2>
+						<p>{% t careers.become_a_craftsman.benefits.transparency_description %}</p>
+					</div>
+				</div>
+				<div class="col-sm-4">
+					<i class="icon-custom rounded-x icon-sm icon-color-red icon-line icon-rocket"></i>
+					<div class="content-boxes-in-v3">
+						<h2 class="heading-sm">
+							<span>{% t careers.become_a_craftsman.benefits.autonomy_title %}</span>
+						</h2>
+						<p>{% t careers.become_a_craftsman.benefits.autonomy_description %}</p>
+					</div>
+				</div>
+			</div>
+
+
+			<div class="row">
+				<div class="heading heading-v4">
+					<h3>{% t careers.become_a_craftsman.benefits.lifestyle_title %}</h3> 
+				</div>
+			</div>
+
+			<div class="row content-boxes-v3 margin-bottom-40 margin-top-20">
+				<div class="col-sm-4 sm-margin-bottom-40">
+					<i class="icon-custom rounded-x icon-sm icon-color-u fa fa-lightbulb-o"></i>
+					<div class="content-boxes-in-v3">
+						<h2 class="heading-sm">
+							<span>{% t careers.become_a_craftsman.benefits.holidays_title %}</span>
+						</h2>
+						<p>{% t careers.become_a_craftsman.benefits.holidays_description %}</p>
+					</div>
+				</div>
+				<div class="col-sm-4 sm-margin-bottom-40 bg-grey">
+					<i class="icon-custom rounded-x icon-sm icon-color-blue fa fa-bullhorn"></i>
+					<div class="content-boxes-in-v3">
+						<h2 class="heading-sm">
+							<span>{% t careers.become_a_craftsman.benefits.pensions_title %}</span>
+						</h2>
+						<p>{% t careers.become_a_craftsman.benefits.pensions_description %}</p>
+					</div>
+				</div>
+				<div class="col-sm-4">
+					<i class="icon-custom rounded-x icon-sm icon-color-red icon-line icon-rocket"></i>
+					<div class="content-boxes-in-v3">
+						<h2 class="heading-sm">
+							<span>{% t careers.become_a_craftsman.benefits.life_cover_title %}</span>
+						</h2>
+						<p>{% t careers.become_a_craftsman.benefits.life_cover_description %}</p>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="row">
+	<div class="col-md-12">
+		<div class="col-md-3 col-md-offset-9">
+			<button class="btn btn-u btn-more" data-toggle="modal" data-target="#craftsman-form">{% t careers-become_a_craftsman.apply_title %}</button>
+		</div>
+	</div>
+</div>
+

--- a/careers/become_a_craftsman.html
+++ b/careers/become_a_craftsman.html
@@ -20,7 +20,7 @@ title: Become a Craftsman
                 </div>
             </div>
 
-            <div class="row">
+            <div class="row margin-bottom-20">
                  <p class="space-lg-hor">Our craftsmen are practitioners, teachers, mentors, and leaders. We will assess your expertise in the following areas to see if you are a fit for us, this will also help you understand if we are a fit for you.</p>
             </div>
 

--- a/careers/become_a_craftsman.html
+++ b/careers/become_a_craftsman.html
@@ -74,15 +74,14 @@ title: Become a Craftsman
 <div>
 	<div class="container content-md">
 
-		<h2 class="title-v2 title-center">{% t careers.become_a_craftsman.benefits.title %}</h2>
-		<p class="space-lg-hor">{% t careers.become_a_craftsman.benefits.description %}</p>
+		<h2 class="title-v2 title-center">{% t careers.benefits.title %}</h2>
+		<p class="space-lg-hor">{% t careers.benefits.description %}</p>
 
 		<div class="row">
 			<div class="heading heading-v4">
-				<h3>{% t careers.become_a_craftsman.benefits.learning_title%}</h3> 
+				<h3>{% t careers.benefits.learning_title%}</h3> 
 			</div>
 		</div>
-
 
 		<div> 
 			<div class="row content-boxes-v3 margin-bottom-20 margin-top-20">
@@ -90,27 +89,27 @@ title: Become a Craftsman
 					<i class="icon-custom rounded-x icon-sm icon-bg-u fa fa-lightbulb-o"></i>
 					<div class="content-boxes-in-v3">
 						<h2 class="heading-sm">
-							<span>{% t careers.become_a_craftsman.benefits.conf_title%}</span>
+							<span>{% t careers.benefits.conf_title%}</span>
 						</h2>
-						<p>{% t careers.become_a_craftsman.benefits.conf_description %}</p>
+						<p>{% t careers.benefits.conf_description %}</p>
 					</div>
 				</div>
 				<div class="col-sm-4 sm-margin-bottom-40 bg-grey">
 					<i class="icon-custom rounded-x icon-sm icon-bg-blue fa fa-bullhorn"></i>
 					<div class="content-boxes-in-v3">
 						<h2 class="heading-sm">
-							<span>{% t careers.become_a_craftsman.benefits.training_title%}</span>
+							<span>{% t careers.benefits.training_title%}</span>
 						</h2>
-						<p>{% t careers.become_a_craftsman.benefits.training_description %}</p>
+						<p>{% t careers.benefits.training_description %}</p>
 					</div>
 				</div>
 				<div class="col-sm-4">
 					<i class="icon-custom rounded-x icon-sm icon-bg-red icon-line icon-rocket"></i>
 					<div class="content-boxes-in-v3">
 						<h2 class="heading-sm">
-							<span>{% t careers.become_a_craftsman.benefits.books_title %}</span>
+							<span>{% t careers.benefits.books_title %}</span>
 						</h2>
-						<p>{% t careers.become_a_craftsman.benefits.books_description %}</p>
+						<p>{% t careers.benefits.books_description %}</p>
 					</div>
 				</div>
 			</div>
@@ -118,7 +117,7 @@ title: Become a Craftsman
 
 			<div class="row">
 				<div class="heading heading-v4">
-					<h3>{% t careers.become_a_craftsman.benefits.culture_title %}</h3> 
+					<h3>{% t careers.benefits.culture_title %}</h3> 
 				</div>
 			</div>
 
@@ -127,27 +126,27 @@ title: Become a Craftsman
 					<i class="icon-custom rounded-x icon-sm icon-color-u fa fa-lightbulb-o"></i>
 					<div class="content-boxes-in-v3">
 						<h2 class="heading-sm">
-							<span>{% t careers.become_a_craftsman.benefits.experts_title %}</span>
+							<span>{% t careers.benefits.experts_title %}</span>
 						</h2>
-						<p>{% t careers.become_a_craftsman.benefits.experts_description %}</p>
+						<p>{% t careers.benefits.experts_description %}</p>
 					</div>
 				</div>
 				<div class="col-sm-4 sm-margin-bottom-40 bg-grey">
 					<i class="icon-custom rounded-x icon-sm icon-color-blue fa fa-bullhorn"></i>
 					<div class="content-boxes-in-v3">
 						<h2 class="heading-sm">
-							<span>{% t careers.become_a_craftsman.benefits.transparency_title %}</span>
+							<span>{% t careers.benefits.transparency_title %}</span>
 						</h2>
-						<p>{% t careers.become_a_craftsman.benefits.transparency_description %}</p>
+						<p>{% t careers.benefits.transparency_description %}</p>
 					</div>
 				</div>
 				<div class="col-sm-4">
 					<i class="icon-custom rounded-x icon-sm icon-color-red icon-line icon-rocket"></i>
 					<div class="content-boxes-in-v3">
 						<h2 class="heading-sm">
-							<span>{% t careers.become_a_craftsman.benefits.autonomy_title %}</span>
+							<span>{% t careers.benefits.autonomy_title %}</span>
 						</h2>
-						<p>{% t careers.become_a_craftsman.benefits.autonomy_description %}</p>
+						<p>{% t careers.benefits.autonomy_description %}</p>
 					</div>
 				</div>
 			</div>
@@ -155,7 +154,7 @@ title: Become a Craftsman
 
 			<div class="row">
 				<div class="heading heading-v4">
-					<h3>{% t careers.become_a_craftsman.benefits.lifestyle_title %}</h3> 
+					<h3>{% t careers.benefits.lifestyle_title %}</h3> 
 				</div>
 			</div>
 
@@ -164,27 +163,27 @@ title: Become a Craftsman
 					<i class="icon-custom rounded-x icon-sm icon-color-u fa fa-lightbulb-o"></i>
 					<div class="content-boxes-in-v3">
 						<h2 class="heading-sm">
-							<span>{% t careers.become_a_craftsman.benefits.holidays_title %}</span>
+							<span>{% t careers.benefits.holidays_title %}</span>
 						</h2>
-						<p>{% t careers.become_a_craftsman.benefits.holidays_description %}</p>
+						<p>{% t careers.benefits.holidays_description %}</p>
 					</div>
 				</div>
 				<div class="col-sm-4 sm-margin-bottom-40 bg-grey">
 					<i class="icon-custom rounded-x icon-sm icon-color-blue fa fa-bullhorn"></i>
 					<div class="content-boxes-in-v3">
 						<h2 class="heading-sm">
-							<span>{% t careers.become_a_craftsman.benefits.pensions_title %}</span>
+							<span>{% t careers.benefits.pensions_title %}</span>
 						</h2>
-						<p>{% t careers.become_a_craftsman.benefits.pensions_description %}</p>
+						<p>{% t careers.benefits.pensions_description %}</p>
 					</div>
 				</div>
 				<div class="col-sm-4">
 					<i class="icon-custom rounded-x icon-sm icon-color-red icon-line icon-rocket"></i>
 					<div class="content-boxes-in-v3">
 						<h2 class="heading-sm">
-							<span>{% t careers.become_a_craftsman.benefits.life_cover_title %}</span>
+							<span>{% t careers.benefits.life_cover_title %}</span>
 						</h2>
-						<p>{% t careers.become_a_craftsman.benefits.life_cover_description %}</p>
+						<p>{% t careers.benefits.life_cover_description %}</p>
 					</div>
 				</div>
 			</div>

--- a/careers/become_a_craftsman.html
+++ b/careers/become_a_craftsman.html
@@ -18,10 +18,13 @@ title: Become a Craftsman
 								<h2 class="title-v2 title-center">{% t careers-become_a_craftsman.title %}</h2>
 							</div>
 							<div class="col-md-3">
-								<a href="#" class="btn-u btn-u-lg btn-more">{% t careers-become_a_craftsman.apply_title %}</a>
+								<button class="btn btn-u btn-more" data-toggle="modal" data-target="#craftsman-form">{% t careers-become_a_craftsman.apply_title %}</button>
 							</div>
 						</div>
 					</div>
+
+					{% include apply_form.html title="Become a Craftsman" target="craftsman" %}
+
 					<p class="space-lg-hor">Our craftsmen are practitioners, teachers, mentors, and leaders. We will assess your expertise in the following areas to see if you are a fit for us, this will also help you understand if we are a fit for you.</p>
 				</div>
 

--- a/careers/become_a_craftsman.html
+++ b/careers/become_a_craftsman.html
@@ -26,7 +26,7 @@ title: Become a Craftsman
 
             <div class="row">
                 <div class="col-md-4 col-md-offset-4">
-                    <button class="btn btn-u btn-more" data-toggle="modal" data-target="#apprentice-form">{% t careers.become_a_craftsman.apply_title %}</button>
+                    <button class="btn btn-u btn-more" data-toggle="modal" data-target="#craftsman-form">{% t careers.become_a_craftsman.apply_title %}</button>
                 </div>
             </div>
             
@@ -198,7 +198,7 @@ title: Become a Craftsman
 
         <div class="row text-center">
             <div class="col-md-4 col-md-offset-4">
-                <button class="btn btn-u btn-more" data-toggle="modal" data-target="#apprentice-form">{% t careers.become_a_craftsman.apply_title %}</button>
+                <button class="btn btn-u btn-more" data-toggle="modal" data-target="#craftsman-form">{% t careers.become_a_craftsman.apply_title %}</button>
             </div>
         </div>
 

--- a/careers/become_a_craftsman.html
+++ b/careers/become_a_craftsman.html
@@ -4,198 +4,198 @@ title: Become a Craftsman
 
 ---
 <div class="breadcrumbs-v3 ourpeople">
-	<div class="container text-center">
-	</div>
+    <div class="container text-center">
+    </div>
 </div>
 
 
 <div class="bg-color-light">
-	<div class="container content-md">
-		<div class="text-center margin-bottom-60">
-			<div class="row">
-				<div class="col-md-12">
-					<div class="col-md-offset-3 col-md-6 margin-top-10">
-						<h2 class="title-v2 title-center">{% t careers-become_a_craftsman.title %}</h2>
-					</div>
-					<div class="col-md-3">
-						<button class="btn btn-u btn-more" data-toggle="modal" data-target="#craftsman-form">{% t careers-become_a_craftsman.apply_title %}</button>
-					</div>
-				</div>
-			</div>
+    <div class="container content-md">
+        <div class="text-center margin-bottom-60">
+            <div class="row">
+                <div class="col-md-12">
+                    <div class="col-md-offset-3 col-md-6 margin-top-10">
+                        <h2 class="title-v2 title-center">{% t careers-become_a_craftsman.title %}</h2>
+                    </div>
+                    <div class="col-md-3">
+                        <button class="btn btn-u btn-more" data-toggle="modal" data-target="#craftsman-form">{% t careers-become_a_craftsman.apply_title %}</button>
+                    </div>
+                </div>
+            </div>
 
-			{% include apply_form.html title="Become a Craftsman" target="craftsman" %}
+            {% include apply_form.html title="Become a Craftsman" target="craftsman" %}
 
-			<p class="space-lg-hor">Our craftsmen are practitioners, teachers, mentors, and leaders. We will assess your expertise in the following areas to see if you are a fit for us, this will also help you understand if we are a fit for you.</p>
-		</div>
+            <p class="space-lg-hor">Our craftsmen are practitioners, teachers, mentors, and leaders. We will assess your expertise in the following areas to see if you are a fit for us, this will also help you understand if we are a fit for you.</p>
+        </div>
 
-		<div class="row margin-bottom-30">
-			<div class="col-sm-6 sm-margin-bottom-50 animated fadeIn wow" data-wow-duration="1.5s">
-				<div class="service-block-v8">
-					<i class="icon-bubbles"></i>
-					<div class="service-block-desc">
-						<h3> {% t careers.become_a_craftsman.practices_title %} </h3>
-						<p> {% t careers.become_a_craftsman.practices_description %}</p>
-					</div>
-				</div>
-			</div>
-			<div class="col-sm-6 sm-margin-bottom-20 animated fadeIn wow" data-wow-duration="1.5s" data-wow-delay=".3s">
-				<div class="service-block-v8">
-					<i class="icon-globe"></i>
-					<div class="service-block-desc">
-						<h3> {% t careers.become_a_craftsman.design_title %} </h3>
-						<p> {% t careers.become_a_craftsman.design_description %} </p>
-					</div>
-				</div>
-			</div>
-		</div>
-		<div class="row margin-bottom-30">
-			<div class="col-sm-6 sm-margin-bottom-50 animated fadeIn wow" data-wow-duration="1.5s">
-				<div class="service-block-v8">
-					<i class="icon-bubbles"></i>
-					<div class="service-block-desc">
-						<h3> {% t careers.become_a_craftsman.technology_stacks_title %} </h3>
-						<p> {% t careers.become_a_craftsman.technology_stacks_description %}</p>
-					</div>
-				</div>
-			</div>
-			<div class="col-sm-6 sm-margin-bottom-20 animated fadeIn wow" data-wow-duration="1.5s" data-wow-delay=".3s">
-				<div class="service-block-v8">
-					<i class="icon-globe"></i>
-					<div class="service-block-desc">
-						<h3> {% t careers.become_a_craftsman.personality_title %} </h3>
-						<p> {% t careers.become_a_craftsman.personality_description %} </p>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
+        <div class="row margin-bottom-30">
+            <div class="col-sm-6 sm-margin-bottom-50 animated fadeIn wow" data-wow-duration="1.5s">
+                <div class="service-block-v8">
+                    <i class="icon-bubbles"></i>
+                    <div class="service-block-desc">
+                        <h3> {% t careers.become_a_craftsman.practices_title %} </h3>
+                        <p> {% t careers.become_a_craftsman.practices_description %}</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-6 sm-margin-bottom-20 animated fadeIn wow" data-wow-duration="1.5s" data-wow-delay=".3s">
+                <div class="service-block-v8">
+                    <i class="icon-globe"></i>
+                    <div class="service-block-desc">
+                        <h3> {% t careers.become_a_craftsman.design_title %} </h3>
+                        <p> {% t careers.become_a_craftsman.design_description %} </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="row margin-bottom-30">
+            <div class="col-sm-6 sm-margin-bottom-50 animated fadeIn wow" data-wow-duration="1.5s">
+                <div class="service-block-v8">
+                    <i class="icon-bubbles"></i>
+                    <div class="service-block-desc">
+                        <h3> {% t careers.become_a_craftsman.technology_stacks_title %} </h3>
+                        <p> {% t careers.become_a_craftsman.technology_stacks_description %}</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-6 sm-margin-bottom-20 animated fadeIn wow" data-wow-duration="1.5s" data-wow-delay=".3s">
+                <div class="service-block-v8">
+                    <i class="icon-globe"></i>
+                    <div class="service-block-desc">
+                        <h3> {% t careers.become_a_craftsman.personality_title %} </h3>
+                        <p> {% t careers.become_a_craftsman.personality_description %} </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 
 <div>
-	<div class="container content-md">
+    <div class="container content-md">
 
-		<h2 class="title-v2 title-center">{% t careers.benefits.title %}</h2>
-		<p class="space-lg-hor">{% t careers.benefits.description %}</p>
+        <h2 class="title-v2 title-center">{% t careers.benefits.title %}</h2>
+        <p class="space-lg-hor">{% t careers.benefits.description %}</p>
 
-		<div class="row">
-			<div class="heading heading-v4">
-				<h3>{% t careers.benefits.learning_title%}</h3> 
-			</div>
-		</div>
+        <div class="row">
+            <div class="heading heading-v4">
+                <h3>{% t careers.benefits.learning_title%}</h3> 
+            </div>
+        </div>
 
-		<div> 
-			<div class="row content-boxes-v3 margin-bottom-20 margin-top-20">
-				<div class="col-sm-4 sm-margin-bottom-40">
-					<i class="icon-custom rounded-x icon-sm icon-bg-u fa fa-lightbulb-o"></i>
-					<div class="content-boxes-in-v3">
-						<h2 class="heading-sm">
-							<span>{% t careers.benefits.conf_title%}</span>
-						</h2>
-						<p>{% t careers.benefits.conf_description %}</p>
-					</div>
-				</div>
-				<div class="col-sm-4 sm-margin-bottom-40 bg-grey">
-					<i class="icon-custom rounded-x icon-sm icon-bg-blue fa fa-bullhorn"></i>
-					<div class="content-boxes-in-v3">
-						<h2 class="heading-sm">
-							<span>{% t careers.benefits.training_title%}</span>
-						</h2>
-						<p>{% t careers.benefits.training_description %}</p>
-					</div>
-				</div>
-				<div class="col-sm-4">
-					<i class="icon-custom rounded-x icon-sm icon-bg-red icon-line icon-rocket"></i>
-					<div class="content-boxes-in-v3">
-						<h2 class="heading-sm">
-							<span>{% t careers.benefits.books_title %}</span>
-						</h2>
-						<p>{% t careers.benefits.books_description %}</p>
-					</div>
-				</div>
-			</div>
-
-
-			<div class="row">
-				<div class="heading heading-v4">
-					<h3>{% t careers.benefits.culture_title %}</h3> 
-				</div>
-			</div>
-
-			<div class="row content-boxes-v3 margin-bottom-20 margin-top-20">
-				<div class="col-sm-4 sm-margin-bottom-40">
-					<i class="icon-custom rounded-x icon-sm icon-color-u fa fa-lightbulb-o"></i>
-					<div class="content-boxes-in-v3">
-						<h2 class="heading-sm">
-							<span>{% t careers.benefits.experts_title %}</span>
-						</h2>
-						<p>{% t careers.benefits.experts_description %}</p>
-					</div>
-				</div>
-				<div class="col-sm-4 sm-margin-bottom-40 bg-grey">
-					<i class="icon-custom rounded-x icon-sm icon-color-blue fa fa-bullhorn"></i>
-					<div class="content-boxes-in-v3">
-						<h2 class="heading-sm">
-							<span>{% t careers.benefits.transparency_title %}</span>
-						</h2>
-						<p>{% t careers.benefits.transparency_description %}</p>
-					</div>
-				</div>
-				<div class="col-sm-4">
-					<i class="icon-custom rounded-x icon-sm icon-color-red icon-line icon-rocket"></i>
-					<div class="content-boxes-in-v3">
-						<h2 class="heading-sm">
-							<span>{% t careers.benefits.autonomy_title %}</span>
-						</h2>
-						<p>{% t careers.benefits.autonomy_description %}</p>
-					</div>
-				</div>
-			</div>
+        <div> 
+            <div class="row content-boxes-v3 margin-bottom-20 margin-top-20">
+                <div class="col-sm-4 sm-margin-bottom-40">
+                    <i class="icon-custom rounded-x icon-sm icon-bg-u fa fa-lightbulb-o"></i>
+                    <div class="content-boxes-in-v3">
+                        <h2 class="heading-sm">
+                            <span>{% t careers.benefits.conf_title%}</span>
+                        </h2>
+                        <p>{% t careers.benefits.conf_description %}</p>
+                    </div>
+                </div>
+                <div class="col-sm-4 sm-margin-bottom-40 bg-grey">
+                    <i class="icon-custom rounded-x icon-sm icon-bg-blue fa fa-bullhorn"></i>
+                    <div class="content-boxes-in-v3">
+                        <h2 class="heading-sm">
+                            <span>{% t careers.benefits.training_title%}</span>
+                        </h2>
+                        <p>{% t careers.benefits.training_description %}</p>
+                    </div>
+                </div>
+                <div class="col-sm-4">
+                    <i class="icon-custom rounded-x icon-sm icon-bg-red icon-line icon-rocket"></i>
+                    <div class="content-boxes-in-v3">
+                        <h2 class="heading-sm">
+                            <span>{% t careers.benefits.books_title %}</span>
+                        </h2>
+                        <p>{% t careers.benefits.books_description %}</p>
+                    </div>
+                </div>
+            </div>
 
 
-			<div class="row">
-				<div class="heading heading-v4">
-					<h3>{% t careers.benefits.lifestyle_title %}</h3> 
-				</div>
-			</div>
+            <div class="row">
+                <div class="heading heading-v4">
+                    <h3>{% t careers.benefits.culture_title %}</h3> 
+                </div>
+            </div>
 
-			<div class="row content-boxes-v3 margin-bottom-40 margin-top-20">
-				<div class="col-sm-4 sm-margin-bottom-40">
-					<i class="icon-custom rounded-x icon-sm icon-color-u fa fa-lightbulb-o"></i>
-					<div class="content-boxes-in-v3">
-						<h2 class="heading-sm">
-							<span>{% t careers.benefits.holidays_title %}</span>
-						</h2>
-						<p>{% t careers.benefits.holidays_description %}</p>
-					</div>
-				</div>
-				<div class="col-sm-4 sm-margin-bottom-40 bg-grey">
-					<i class="icon-custom rounded-x icon-sm icon-color-blue fa fa-bullhorn"></i>
-					<div class="content-boxes-in-v3">
-						<h2 class="heading-sm">
-							<span>{% t careers.benefits.pensions_title %}</span>
-						</h2>
-						<p>{% t careers.benefits.pensions_description %}</p>
-					</div>
-				</div>
-				<div class="col-sm-4">
-					<i class="icon-custom rounded-x icon-sm icon-color-red icon-line icon-rocket"></i>
-					<div class="content-boxes-in-v3">
-						<h2 class="heading-sm">
-							<span>{% t careers.benefits.life_cover_title %}</span>
-						</h2>
-						<p>{% t careers.benefits.life_cover_description %}</p>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
+            <div class="row content-boxes-v3 margin-bottom-20 margin-top-20">
+                <div class="col-sm-4 sm-margin-bottom-40">
+                    <i class="icon-custom rounded-x icon-sm icon-color-u fa fa-lightbulb-o"></i>
+                    <div class="content-boxes-in-v3">
+                        <h2 class="heading-sm">
+                            <span>{% t careers.benefits.experts_title %}</span>
+                        </h2>
+                        <p>{% t careers.benefits.experts_description %}</p>
+                    </div>
+                </div>
+                <div class="col-sm-4 sm-margin-bottom-40 bg-grey">
+                    <i class="icon-custom rounded-x icon-sm icon-color-blue fa fa-bullhorn"></i>
+                    <div class="content-boxes-in-v3">
+                        <h2 class="heading-sm">
+                            <span>{% t careers.benefits.transparency_title %}</span>
+                        </h2>
+                        <p>{% t careers.benefits.transparency_description %}</p>
+                    </div>
+                </div>
+                <div class="col-sm-4">
+                    <i class="icon-custom rounded-x icon-sm icon-color-red icon-line icon-rocket"></i>
+                    <div class="content-boxes-in-v3">
+                        <h2 class="heading-sm">
+                            <span>{% t careers.benefits.autonomy_title %}</span>
+                        </h2>
+                        <p>{% t careers.benefits.autonomy_description %}</p>
+                    </div>
+                </div>
+            </div>
+
+
+            <div class="row">
+                <div class="heading heading-v4">
+                    <h3>{% t careers.benefits.lifestyle_title %}</h3> 
+                </div>
+            </div>
+
+            <div class="row content-boxes-v3 margin-bottom-40 margin-top-20">
+                <div class="col-sm-4 sm-margin-bottom-40">
+                    <i class="icon-custom rounded-x icon-sm icon-color-u fa fa-lightbulb-o"></i>
+                    <div class="content-boxes-in-v3">
+                        <h2 class="heading-sm">
+                            <span>{% t careers.benefits.holidays_title %}</span>
+                        </h2>
+                        <p>{% t careers.benefits.holidays_description %}</p>
+                    </div>
+                </div>
+                <div class="col-sm-4 sm-margin-bottom-40 bg-grey">
+                    <i class="icon-custom rounded-x icon-sm icon-color-blue fa fa-bullhorn"></i>
+                    <div class="content-boxes-in-v3">
+                        <h2 class="heading-sm">
+                            <span>{% t careers.benefits.pensions_title %}</span>
+                        </h2>
+                        <p>{% t careers.benefits.pensions_description %}</p>
+                    </div>
+                </div>
+                <div class="col-sm-4">
+                    <i class="icon-custom rounded-x icon-sm icon-color-red icon-line icon-rocket"></i>
+                    <div class="content-boxes-in-v3">
+                        <h2 class="heading-sm">
+                            <span>{% t careers.benefits.life_cover_title %}</span>
+                        </h2>
+                        <p>{% t careers.benefits.life_cover_description %}</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 
 <div class="row">
-	<div class="col-md-12">
-		<div class="col-md-3 col-md-offset-9">
-			<button class="btn btn-u btn-more" data-toggle="modal" data-target="#craftsman-form">{% t careers-become_a_craftsman.apply_title %}</button>
-		</div>
-	</div>
+    <div class="col-md-12">
+        <div class="col-md-3 col-md-offset-9">
+            <button class="btn btn-u btn-more" data-toggle="modal" data-target="#craftsman-form">{% t careers-become_a_craftsman.apply_title %}</button>
+        </div>
+    </div>
 </div>
 

--- a/careers/become_a_craftsman.html
+++ b/careers/become_a_craftsman.html
@@ -3,315 +3,190 @@ layout: default
 title: Become a Craftsman
 
 ---
-
 <div class="breadcrumbs-v3 ourpeople">
     <div class="container text-center">
-        <h1>{% t careers.title %}</h1>
     </div>
 </div>
 
-<div class="container content">
-    <div class="row">
-        <div class="col-md-12">
-            <div class="col-md-offset-3 col-md-6 text-center margin-top-10">
-                <h2>{% t careers-become_a_craftsman.title %}</h2>
-            </div>
-            <div class="col-md-3">
-                <a href="#" class="btn-u btn-u-lg btn-more">{% t careers-become_a_craftsman.apply_title %}</a>
-            </div>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-md-12">
-            <div class="margin-bottom-40">
-                <div class="headline">
-                    <h2>{% t careers.become_a_craftsman.join_title %}</h2>
-                </div>
-                {% t careers.become_a_craftsman.join_description %}
-            </div>
-            <div class="margin-bottom-40">
-                <a id="joiningcodurance"></a>
-                <div class="headline">
-                    <h2>Software Craftsman</h2>
-                </div>
-                <h3> {% t careers.become_a_craftsman.practices_title %} </h3>
-                {% t careers.become_a_craftsman.practices_description %}
-                <h3>{% t careers.become_a_craftsman.design_title %}</h3>
-                {% t careers.become_a_craftsman.design_description %}
-                <h3>{% t careers.become_a_craftsman.technology_stacks_title %}</h3>
-                {% t careers.become_a_craftsman.technology_stacks_description %}
-                <h3>{% t careers.become_a_craftsman.personality_title %}</h3>
-                {% t careers.become_a_craftsman.personality_description %}
-            </div>
-            <div class="margin-bottom-40">
-                <div class="headline">
-                    <h2>{% t careers.become_a_craftsman.hiring_title %}</h2>
-                </div>
-                {% t careers.become_a_craftsman.hiring_description %}
-            </div>
-        </div>
-    </div>
-</div>
 
-<div class="container ">
-    <div class="row">
-        <div class="col-md-12">
-            <div class="headline">
-                <h2>{% t careers.become_a_craftsman.benefits_title %}</h2>
+		<div class="bg-color-light">
+			<div class="container content-md">
+				<div class="text-center margin-bottom-60">
+					<div class="row">
+						<div class="col-md-12">
+							<div class="col-md-offset-3 col-md-6 margin-top-10">
+								<h2 class="title-v2 title-center">{% t careers-become_a_craftsman.title %}</h2>
+							</div>
+							<div class="col-md-3">
+								<a href="#" class="btn-u btn-u-lg btn-more">{% t careers-become_a_craftsman.apply_title %}</a>
+							</div>
+						</div>
+					</div>
+					<p class="space-lg-hor">Our craftsmen are practitioners, teachers, mentors, and leaders. We will assess your expertise in the following areas to see if you are a fit for us, this will also help you understand if we are a fit for you.</p>
+				</div>
+
+				<div class="row margin-bottom-30">
+					<div class="col-sm-6 sm-margin-bottom-50 animated fadeIn wow" data-wow-duration="1.5s">
+						<div class="service-block-v8">
+							<i class="icon-bubbles"></i>
+							<div class="service-block-desc">
+								<h3> {% t careers.become_a_craftsman.practices_title %} </h3>
+								<p> {% t careers.become_a_craftsman.practices_description %}</p>
+							</div>
+						</div>
+					</div>
+					<div class="col-sm-6 sm-margin-bottom-20 animated fadeIn wow" data-wow-duration="1.5s" data-wow-delay=".3s">
+						<div class="service-block-v8">
+							<i class="icon-globe"></i>
+							<div class="service-block-desc">
+								<h3> {% t careers.become_a_craftsman.design_title %} </h3>
+								<p> {% t careers.become_a_craftsman.design_description %} </p>
+							</div>
+						</div>
+					</div>
+				</div>
+				<div class="row margin-bottom-30">
+					<div class="col-sm-6 sm-margin-bottom-50 animated fadeIn wow" data-wow-duration="1.5s">
+						<div class="service-block-v8">
+							<i class="icon-bubbles"></i>
+							<div class="service-block-desc">
+								<h3> {% t careers.become_a_craftsman.technology_stacks_title %} </h3>
+								<p> {% t careers.become_a_craftsman.technology_stacks_description %}</p>
+							</div>
+						</div>
+					</div>
+					<div class="col-sm-6 sm-margin-bottom-20 animated fadeIn wow" data-wow-duration="1.5s" data-wow-delay=".3s">
+						<div class="service-block-v8">
+							<i class="icon-globe"></i>
+							<div class="service-block-desc">
+								<h3> {% t careers.become_a_craftsman.personality_title %} </h3>
+								<p> {% t careers.become_a_craftsman.personality_description %} </p>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+
+    <div>
+      <div class="container content-md">
+
+        <h2 class="title-v2 title-center">{% t careers.become_a_craftsman.benefits.title %}</h2>
+        <p class="space-lg-hor">{% t careers.become_a_craftsman.benefits.description %}</p>
+
+        <div class="row">
+            <div class="heading heading-v4">
+              <h3>{% t careers.become_a_craftsman.benefits.learning_title%}</h3> 
             </div>
         </div>
-    </div>
-</div>
-<div class="bg-grey">
-    <div class="container content-sm">
-        <div class="row content-boxes-v3 margin-bottom-40">
+
+
+        <div> 
+          <div class="row content-boxes-v3 margin-bottom-20 margin-top-20 bg-grey">
             <div class="col-sm-4 sm-margin-bottom-40">
-                <i class="icon-custom rounded-x icon-sm icon-bg-u fa fa-lightbulb-o"></i>
-                <div class="content-boxes-in-v3">
-                    <h2 class="heading-sm">
-                        <span>Small Icons</span>
-                    </h2>
-                    <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been
-                        the industry's</p>
-                </div>
+              <i class="icon-custom rounded-x icon-sm icon-bg-u fa fa-lightbulb-o"></i>
+              <div class="content-boxes-in-v3">
+                <h2 class="heading-sm">
+                  <span>{% t careers.become_a_craftsman.benefits.conf_title%}</span>
+                </h2>
+                <p>{% t careers.become_a_craftsman.benefits.conf_description %}</p>
+              </div>
             </div>
             <div class="col-sm-4 sm-margin-bottom-40">
-                <i class="icon-custom rounded-x icon-sm icon-bg-blue fa fa-bullhorn"></i>
-                <div class="content-boxes-in-v3">
-                    <h2 class="heading-sm">
-                        <span>Small Icons</span>
-                    </h2>
-                    <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been
-                        the industry's</p>
-                </div>
+              <i class="icon-custom rounded-x icon-sm icon-bg-blue fa fa-bullhorn"></i>
+              <div class="content-boxes-in-v3">
+                <h2 class="heading-sm">
+                  <span>{% t careers.become_a_craftsman.benefits.training_title%}</span>
+                </h2>
+                <p>{% t careers.become_a_craftsman.benefits.training_description %}</p>
+              </div>
             </div>
             <div class="col-sm-4">
-                <i class="icon-custom rounded-x icon-sm icon-bg-red icon-line icon-rocket"></i>
-                <div class="content-boxes-in-v3">
-                    <h2 class="heading-sm">
-                        <span>Small Icons</span>
-                    </h2>
-                    <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been
-                        the industry's</p>
-                </div>
+              <i class="icon-custom rounded-x icon-sm icon-bg-red icon-line icon-rocket"></i>
+              <div class="content-boxes-in-v3">
+                <h2 class="heading-sm">
+                  <span>{% t careers.become_a_craftsman.benefits.books_title %}</span>
+                </h2>
+                <p>{% t careers.become_a_craftsman.benefits.books_description %}</p>
+              </div>
             </div>
-        </div>
+          </div>
 
-        <div class="row content-boxes-v3">
-            <div class="col-sm-4 sm-margin-bottom-40">
-                <i class="icon-custom rounded-x icon-sm icon-color-u fa fa-lightbulb-o"></i>
-                <div class="content-boxes-in-v3">
-                    <h2 class="heading-sm">
-                        <span>Small Icons</span>
-                    </h2>
-                    <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been
-                        the industry's</p>
-                </div>
+
+          <div class="row">
+            <div class="heading heading-v4">
+              <h3>{% t careers.become_a_craftsman.benefits.culture_title %}</h3> 
             </div>
+          </div>
+
+          <div class="row content-boxes-v3 margin-bottom-20 margin-top-20">
             <div class="col-sm-4 sm-margin-bottom-40">
-                <i class="icon-custom rounded-x icon-sm icon-color-blue fa fa-bullhorn"></i>
-                <div class="content-boxes-in-v3">
-                    <h2 class="heading-sm">
-                        <span>Small Icons</span>
-                    </h2>
-                    <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been
-                        the industry's</p>
-                </div>
+              <i class="icon-custom rounded-x icon-sm icon-color-u fa fa-lightbulb-o"></i>
+              <div class="content-boxes-in-v3">
+                <h2 class="heading-sm">
+                  <span>{% t careers.become_a_craftsman.benefits.experts_title %}</span>
+                </h2>
+                <p>{% t careers.become_a_craftsman.benefits.experts_description %}</p>
+              </div>
+            </div>
+            <div class="col-sm-4 sm-margin-bottom-40 bg-grey">
+              <i class="icon-custom rounded-x icon-sm icon-color-blue fa fa-bullhorn"></i>
+              <div class="content-boxes-in-v3">
+                <h2 class="heading-sm">
+                  <span>{% t careers.become_a_craftsman.benefits.transparency_title %}</span>
+                </h2>
+                <p>{% t careers.become_a_craftsman.benefits.transparency_description %}</p>
+              </div>
             </div>
             <div class="col-sm-4">
-                <i class="icon-custom rounded-x icon-sm icon-color-red icon-line icon-rocket"></i>
-                <div class="content-boxes-in-v3">
-                    <h2 class="heading-sm">
-                        <span>Small Icons</span>
-                    </h2>
-                    <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been
-                        the industry's</p>
-                </div>
+              <i class="icon-custom rounded-x icon-sm icon-color-red icon-line icon-rocket"></i>
+              <div class="content-boxes-in-v3">
+                <h2 class="heading-sm">
+                  <span>{% t careers.become_a_craftsman.benefits.autonomy_title %}</span>
+                </h2>
+                <p>{% t careers.become_a_craftsman.benefits.autonomy_description %}</p>
+              </div>
             </div>
+          </div>
+
+
+          <div class="row">
+            <div class="heading heading-v4">
+              <h3>{% t careers.become_a_craftsman.benefits.lifestyle_title %}</h3> 
+            </div>
+          </div>
+
+          <div class="row content-boxes-v3 margin-bottom-40 margin-top-20">
+            <div class="col-sm-4 sm-margin-bottom-40">
+              <i class="icon-custom rounded-x icon-sm icon-color-u fa fa-lightbulb-o"></i>
+              <div class="content-boxes-in-v3">
+                <h2 class="heading-sm">
+                  <span>{% t careers.become_a_craftsman.benefits.holidays_title %}</span>
+                </h2>
+                <p>{% t careers.become_a_craftsman.benefits.holidays_description %}</p>
+              </div>
+            </div>
+            <div class="col-sm-4 sm-margin-bottom-40 bg-grey">
+              <i class="icon-custom rounded-x icon-sm icon-color-blue fa fa-bullhorn"></i>
+              <div class="content-boxes-in-v3">
+                <h2 class="heading-sm">
+                  <span>{% t careers.become_a_craftsman.benefits.pensions_title %}</span>
+                </h2>
+                <p>{% t careers.become_a_craftsman.benefits.pensions_description %}</p>
+              </div>
+            </div>
+            <div class="col-sm-4">
+              <i class="icon-custom rounded-x icon-sm icon-color-red icon-line icon-rocket"></i>
+              <div class="content-boxes-in-v3">
+                <h2 class="heading-sm">
+                  <span>{% t careers.become_a_craftsman.benefits.life_cover_title %}</span>
+                </h2>
+                <p>{% t careers.become_a_craftsman.benefits.life_cover_description %}</p>
+              </div>
+            </div>
+          </div>
         </div>
+      </div>
     </div>
-</div>
-
-<div class="container content">
-    <div class="row">
-        <div class="col-md-8 col-md-offset-2">
-            <div class="headline">
-                <h2>General Questions</h2>
-            </div>
-            <div class="panel-group acc-v1 margin-bottom-40" id="accordion">
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <h4 class="panel-title">
-                            <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion"
-                               href="#collapseOne" aria-expanded="true">
-                                1. Put a bird on it squid single-origin coffee nulla?
-                            </a>
-                        </h4>
-                    </div>
-                    <div id="collapseOne" class="panel-collapse collapse in" aria-expanded="true">
-                        <div class="panel-body">
-                            Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad
-                            squid. 3 wolf moon officia aute,
-                            non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod. Brunch 3
-                            wolf moon tempor, sunt
-                            aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et.
-                        </div>
-                    </div>
-                </div>
-
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <h4 class="panel-title">
-                            <a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#accordion"
-                               href="#collapseTwo" aria-expanded="false">
-                                2. Oliva pariatur cliche reprehenderit high life accusamus?
-                            </a>
-                        </h4>
-                    </div>
-                    <div id="collapseTwo" class="panel-collapse collapse" aria-expanded="false" style="height: 0px;">
-                        <div class="panel-body">
-                            <p>Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad
-                                squid. Nihil anim keffiyeh
-                                helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident.</p>
-                            <ul class="list-unstyled">
-                                <li><i class="fa fa-check color-green"></i> Donec id elit non mi porta gravida at eget
-                                    metus..
-                                </li>
-                                <li><i class="fa fa-check color-green"></i> Fusce dapibus, tellus ac cursus comodo
-                                    egetine..
-                                </li>
-                                <li><i class="fa fa-check color-green"></i> Food truck quinoa nesciunt laborum eiusmod
-                                    runch..
-                                </li>
-                                <li><i class="fa fa-check color-green"></i> Donec id elit non mi porta gravida at eget
-                                    metus..
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <h4 class="panel-title">
-                            <a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#accordion"
-                               href="#collapseThree" aria-expanded="false">
-                                3. Enim eiusmod high life accusamus terry richardson?
-                            </a>
-                        </h4>
-                    </div>
-                    <div id="collapseThree" class="panel-collapse collapse" aria-expanded="false" style="height: 0px;">
-                        <div class="panel-body">
-                            <p>Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea
-                                proident. Food truck quinoa
-                                nesciunt laborum eiusmodolf moon tempor, sunt aliqua put a bird.</p>
-                            <ul class="list-unstyled">
-                                <li><i class="fa fa-check color-green"></i> Donec id elit non mi porta gravida at eget
-                                    metus..
-                                </li>
-                                <li><i class="fa fa-check color-green"></i> Fusce dapibus, tellus ac cursus comodo
-                                    egetine..
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <h4 class="panel-title">
-                            <a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#accordion"
-                               href="#collapseFour" aria-expanded="false">
-                                4. Livil anim keffiyeh helvetica craft beer labore wesde brunch?
-                            </a>
-                        </h4>
-                    </div>
-                    <div id="collapseFour" class="panel-collapse collapse" aria-expanded="false">
-                        <div class="panel-body">
-                            Olif moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt
-                            laborum eiusmod. Brunch 3 wolf
-                            moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda
-                            shoreditch et.
-                        </div>
-                    </div>
-                </div>
-
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <h4 class="panel-title">
-                            <a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#accordion"
-                               href="#collapseFive" aria-expanded="false">
-                                5. Leggings occaecat craft beer farmto tableraw denim?
-                            </a>
-                        </h4>
-                    </div>
-                    <div id="collapseFive" class="panel-collapse collapse" aria-expanded="false">
-                        <div class="panel-body">
-                            <p>Keffiyeh anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente
-                                ea proident. Ad vegan excepteur
-                                butcher vice lomo. Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid
-                                single-origin coffee nulla assumenda
-                                shoreditch et.</p>
-                            <ul class="list-unstyled">
-                                <li><i class="fa fa-check color-green"></i> Donec id elit non mi porta gravida at eget
-                                    metus..
-                                </li>
-                                <li><i class="fa fa-check color-green"></i> Fusce dapibus, tellus ac cursus comodo
-                                    egetine..
-                                </li>
-                                <li><i class="fa fa-check color-green"></i> Food truck quinoa nesciunt laborum eiusmod
-                                    runch..
-                                </li>
-                                <li><i class="fa fa-check color-green"></i> Donec id elit non mi porta gravida at eget
-                                    metus..
-                                </li>
-                                <li><i class="fa fa-check color-green"></i> Fusce dapibus, tellus ac cursus comodo
-                                    egetine..
-                                </li>
-                                <li><i class="fa fa-check color-green"></i> Food truck quinoa nesciunt laborum eiusmod
-                                    runch..
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <h4 class="panel-title">
-                            <a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#accordion"
-                               href="#collapseSix" aria-expanded="false">
-                                6. Keffiyeh anim keffiyeh helvetica craft beer labore wesse?
-                            </a>
-                        </h4>
-                    </div>
-                    <div id="collapseSix" class="panel-collapse collapse" aria-expanded="false">
-                        <div class="panel-body">
-                            Helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident. Ad vegan
-                            excepteur butcher vice lomo. Brunch
-                            sunt aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et.
-                        </div>
-                    </div>
-                </div>
-
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <h4 class="panel-title">
-                            <a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#accordion"
-                               href="#collapseSeven" aria-expanded="false">
-                                7. Helvetica craft beer labore wes anderson cred nesciu ntlife richardson?
-                            </a>
-                        </h4>
-                    </div>
-                    <div id="collapseSeven" class="panel-collapse collapse" aria-expanded="false">
-                        <div class="panel-body">
-                            Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad
-                            squid. 3 wolf moon officia aute,
-                            non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod.
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
     </div>
-</div>
+  </div>

--- a/careers/become_a_craftsman.html
+++ b/careers/become_a_craftsman.html
@@ -85,7 +85,7 @@ title: Become a Craftsman
 
 
         <div> 
-          <div class="row content-boxes-v3 margin-bottom-20 margin-top-20 bg-grey">
+          <div class="row content-boxes-v3 margin-bottom-20 margin-top-20">
             <div class="col-sm-4 sm-margin-bottom-40">
               <i class="icon-custom rounded-x icon-sm icon-bg-u fa fa-lightbulb-o"></i>
               <div class="content-boxes-in-v3">
@@ -95,7 +95,7 @@ title: Become a Craftsman
                 <p>{% t careers.become_a_craftsman.benefits.conf_description %}</p>
               </div>
             </div>
-            <div class="col-sm-4 sm-margin-bottom-40">
+            <div class="col-sm-4 sm-margin-bottom-40 bg-grey">
               <i class="icon-custom rounded-x icon-sm icon-bg-blue fa fa-bullhorn"></i>
               <div class="content-boxes-in-v3">
                 <h2 class="heading-sm">

--- a/careers/become_a_craftsman.html
+++ b/careers/become_a_craftsman.html
@@ -17,15 +17,20 @@ title: Become a Craftsman
                     <div class="col-md-offset-3 col-md-6 margin-top-10">
                         <h2 class="title-v2 title-center">{% t careers-become_a_craftsman.title %}</h2>
                     </div>
-                    <div class="col-md-3">
-                        <button class="btn btn-u btn-more" data-toggle="modal" data-target="#craftsman-form">{% t careers-become_a_craftsman.apply_title %}</button>
-                    </div>
                 </div>
             </div>
 
-            {% include apply_form.html title="Become a Craftsman" target="craftsman" %}
+            <div class="row">
+                 <p class="space-lg-hor">Our craftsmen are practitioners, teachers, mentors, and leaders. We will assess your expertise in the following areas to see if you are a fit for us, this will also help you understand if we are a fit for you.</p>
+            </div>
 
-            <p class="space-lg-hor">Our craftsmen are practitioners, teachers, mentors, and leaders. We will assess your expertise in the following areas to see if you are a fit for us, this will also help you understand if we are a fit for you.</p>
+            <div class="row">
+                <div class="col-md-4 col-md-offset-4">
+                    <button class="btn btn-u btn-more" data-toggle="modal" data-target="#apprentice-form">{% t careers.become_a_craftsman.apply_title %}</button>
+                </div>
+            </div>
+            
+            {% include apply_form.html title="Become a Craftsman" target="craftsman" %}
         </div>
 
         <div class="row margin-bottom-30">
@@ -188,14 +193,12 @@ title: Become a Craftsman
                 </div>
             </div>
         </div>
-    </div>
-</div>
 
-<div class="row">
-    <div class="col-md-12">
-        <div class="col-md-3 col-md-offset-9">
-            <button class="btn btn-u btn-more" data-toggle="modal" data-target="#craftsman-form">{% t careers-become_a_craftsman.apply_title %}</button>
+        <div class="row text-center">
+            <div class="col-md-4 col-md-offset-4">
+                <button class="btn btn-u btn-more" data-toggle="modal" data-target="#apprentice-form">{% t careers.become_a_craftsman.apply_title %}</button>
+            </div>
         </div>
+
     </div>
 </div>
-

--- a/careers/become_a_craftsman.html
+++ b/careers/become_a_craftsman.html
@@ -79,8 +79,10 @@ title: Become a Craftsman
 <div>
     <div class="container content-md">
 
-        <h2 class="title-v2 title-center">{% t careers.benefits.title %}</h2>
-        <p class="space-lg-hor">{% t careers.benefits.description %}</p>
+        <div class="margin-bottom-40">
+            <h2 class="title-v2 title-center">{% t careers.benefits.title %}</h2>
+            <p class="space-lg-hor">{% t careers.benefits.description %}</p>
+        </div>
 
         <div class="row">
             <div class="heading heading-v4">
@@ -89,7 +91,7 @@ title: Become a Craftsman
         </div>
 
         <div> 
-            <div class="row content-boxes-v3 margin-bottom-20 margin-top-20">
+            <div class="row content-boxes-v3 margin-bottom-40 margin-top-20">
                 <div class="col-sm-4 sm-margin-bottom-40">
                     <i class="icon-custom rounded-x icon-sm icon-bg-u fa fa-lightbulb-o"></i>
                     <div class="content-boxes-in-v3">
@@ -126,7 +128,7 @@ title: Become a Craftsman
                 </div>
             </div>
 
-            <div class="row content-boxes-v3 margin-bottom-20 margin-top-20">
+            <div class="row content-boxes-v3 margin-bottom-40 margin-top-20">
                 <div class="col-sm-4 sm-margin-bottom-40">
                     <i class="icon-custom rounded-x icon-sm icon-color-u fa fa-lightbulb-o"></i>
                     <div class="content-boxes-in-v3">

--- a/careers/become_an_apprentice.html
+++ b/careers/become_an_apprentice.html
@@ -199,11 +199,17 @@ title: Become an Apprentice
 		</div>
 		<div class="row news-v1">
 			{% assign first_week = site.posts | where:"name","Discovering Codurance during my first week as an apprentice" %}
-			{% include life_of_apprentice_articles.html param=first_week truncated=2 %}
 			{% assign first_year = site.posts | where:"name","my-first-year-at-codurance" %}
-			{% include life_of_apprentice_articles.html param=first_year truncated=5 %}
 			{% assign learning_specification = site.posts | where:"name","Learning Specification By Example from Gojko Adzic" %}
-			{% include life_of_apprentice_articles.html param=learning_specification truncated=2 %}
+                        {% if first_week[0] %}
+                            {% include life_of_apprentice_articles.html param=first_week truncated=2 %}
+                        {% endif %}
+                        {% if first_year[0] %}
+                            {% include life_of_apprentice_articles.html param=first_year truncated=5 %}
+                        {% endif %}
+                        {% if learning_specification[0] %}
+                            {% include life_of_apprentice_articles.html param=learning_specification truncated=2 %}
+                        {% endif %}
 		</div>
 		<div class="row">
 			<div class="col-md-12">

--- a/careers/become_an_apprentice.html
+++ b/careers/become_an_apprentice.html
@@ -195,18 +195,18 @@ title: Become an Apprentice
                 <p>{% t careers.become_an_apprentice.life_apprentice.description  %}</p>
             </div>
         </div>
-        <div class="row news-v1">
+	<div class="row blog-boxes">
             {% assign first_week = site.posts | where:"name","Discovering Codurance during my first week as an apprentice" %}
             {% assign first_year = site.posts | where:"name","my-first-year-at-codurance" %}
             {% assign learning_specification = site.posts | where:"name","Learning Specification By Example from Gojko Adzic" %}
             {% if first_week[0] %}
-                {% include life_of_apprentice_articles.html param=first_week truncated=2 %}
+                {% include life_of_apprentice_articles.html param=first_week truncated_title=2 truncated_abstract=30 %}
             {% endif %}
             {% if first_year[0] %}
-                {% include life_of_apprentice_articles.html param=first_year truncated=5 %}
+                {% include life_of_apprentice_articles.html param=first_year truncated_title=5 truncated_abstract=35 %}
             {% endif %}
             {% if learning_specification[0] %}
-                {% include life_of_apprentice_articles.html param=learning_specification truncated=2 %}
+                {% include life_of_apprentice_articles.html param=learning_specification truncated_title=2 truncated_abstract=30 %}
             {% endif %}
         </div>
         <div class="row">

--- a/careers/become_an_apprentice.html
+++ b/careers/become_an_apprentice.html
@@ -19,7 +19,7 @@ title: Become an Apprentice
                 </div>
             </div>
 
-            <div class="row">
+            <div class="row margin-bottom-20">
                 <p class="space-lg-hor">{% t careers.become_an_apprentice.description %}</p>
             </div>
 

--- a/careers/become_an_apprentice.html
+++ b/careers/become_an_apprentice.html
@@ -71,5 +71,12 @@ title: Become an Apprentice
                 {% include life_of_apprentice_articles.html param=learning_specification truncated=2 %}
             </div>
         </div>
+		<div class="row">
+            <div class="col-md-12">
+                <div class="col-md-3 col-md-offset-9">
+                    <button class="btn btn-u btn-more" data-toggle="modal" data-target="#apprentice-form">{% t careers.become_an_apprentice.apply_title %}</button>
+                </div>
+            </div>
+        </div>
     </div>
 </div>

--- a/careers/become_an_apprentice.html
+++ b/careers/become_an_apprentice.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Become a Apprentice
+title: Become an Apprentice
 ---
 <div class="breadcrumbs-v3 ourpeople">
     <div class="container text-center">
@@ -8,187 +8,89 @@ title: Become a Apprentice
 </div>
 
 
-		<div class="bg-color-light">
-			<div class="container content-md">
-				<div class="text-center margin-bottom-60">
-					<div class="row">
-						<div class="col-md-12">
-							<div class="col-md-offset-3 col-md-6 margin-top-10">
-								<h2 class="title-v2 title-center">{% t careers-become_a_apprentice.title %}</h2>
-							</div>
-							<div class="col-md-3">
-								<button class="btn btn-u btn-more" data-toggle="modal" data-target="#apprentice-form">{% t careers-become_a_apprentice.apply_title %}</button>
-							</div>
-						</div>
-					</div>
+<div class="bg-color-light">
+    <div class="container content-md">
+        <div class="text-center margin-bottom-60">
+            <div class="row">
+                <div class="col-md-12">
+                    <div class="col-md-offset-3 col-md-6 margin-top-10">
+                        <h2 class="title-v2 title-center">{% t careers.become_an_apprentice.title %}</h2>
+                    </div>
+                    <div class="col-md-3">
+                        <button class="btn btn-u btn-more" data-toggle="modal" data-target="#apprentice-form">{% t careers.become_an_apprentice.apply_title %}</button>
+                    </div>
+                </div>
+            </div>
 
-					{% include apply_form.html title="Become an Apprentice" target="apprentice" %}
+            {% include apply_form.html title="Become an Apprentice" target="apprentice" %}
 
-					<p class="space-lg-hor">Our craftsmen are practitioners, teachers, mentors, and leaders. We will assess your expertise in the following areas to see if you are a fit for us, this will also help you understand if we are a fit for you.</p>
-				</div>
+            <p class="space-lg-hor">{% t careers.become_an_apprentice.description %}</p>
 
-				<div class="row margin-bottom-30">
-					<div class="col-sm-6 sm-margin-bottom-50 animated fadeIn wow" data-wow-duration="1.5s">
-						<div class="service-block-v8">
-							<i class="icon-bubbles"></i>
-							<div class="service-block-desc">
-								<h3> {% t careers.become_a_apprentice.practices_title %} </h3>
-								<p> {% t careers.become_a_apprentice.practices_description %}</p>
-							</div>
-						</div>
-					</div>
-					<div class="col-sm-6 sm-margin-bottom-20 animated fadeIn wow" data-wow-duration="1.5s" data-wow-delay=".3s">
-						<div class="service-block-v8">
-							<i class="icon-globe"></i>
-							<div class="service-block-desc">
-								<h3> {% t careers.become_a_apprentice.design_title %} </h3>
-								<p> {% t careers.become_a_apprentice.design_description %} </p>
-							</div>
-						</div>
-					</div>
-				</div>
-				<div class="row margin-bottom-30">
-					<div class="col-sm-6 sm-margin-bottom-50 animated fadeIn wow" data-wow-duration="1.5s">
-						<div class="service-block-v8">
-							<i class="icon-bubbles"></i>
-							<div class="service-block-desc">
-								<h3> {% t careers.become_a_apprentice.technology_stacks_title %} </h3>
-								<p> {% t careers.become_a_apprentice.technology_stacks_description %}</p>
-							</div>
-						</div>
-					</div>
-					<div class="col-sm-6 sm-margin-bottom-20 animated fadeIn wow" data-wow-duration="1.5s" data-wow-delay=".3s">
-						<div class="service-block-v8">
-							<i class="icon-globe"></i>
-							<div class="service-block-desc">
-								<h3> {% t careers.become_a_apprentice.personality_title %} </h3>
-								<p> {% t careers.become_a_apprentice.personality_description %} </p>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-
-    <div>
-      <div class="container content-md">
-
-        <h2 class="title-v2 title-center">{% t careers.become_a_apprentice.benefits.title %}</h2>
-        <p class="space-lg-hor">{% t careers.become_a_apprentice.benefits.description %}</p>
-
-        <div class="row">
-            <div class="heading heading-v4">
-              <h3>{% t careers.become_a_apprentice.benefits.learning_title%}</h3> 
+            <div class="row">
+                <div class="col-md-12">
+                    <div class="margin-bottom-40">
+                        <div class="headline">
+                            <h2>{% t careers.become_an_apprentice.how_works_title%}</h2>
+                        </div>
+                        <p>{% t careers.become_an_apprentice.how_works_description%}</p>
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-12">
+                    <div class="margin-bottom-40">
+                        <div class="headline">
+                            <h2>{% t careers.become_an_apprentice.background_title%}</h2>
+                        </div>
+                        <p>{% t careers.become_an_apprentice.background_description%}</p>
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-12">
+                    <div class="margin-bottom-40">
+                        <div class="headline">
+                            <h2>{% t careers.become_an_apprentice.is_it_for_me_title%}</h2>
+                        </div>
+                        <p>{% t careers.become_an_apprentice.is_it_for_me_description%}</p>
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-offset-3 col-md-6 text-center">
+                    <h2>{% t careers.become_an_apprentice.life_apprentice.title %}</h2>
+                    <p>{% t careers.become_an_apprentice.life_apprentice.description  %}</p>
+                </div>
+            </div>
+            <div class="row news-v1">
+                <div class="col-md-4 md-margin-bottom-40">
+                    <div class="news-v1-in">
+                        <img class="img-responsive" alt="" src="/assets/img/custom/careers/ourpeople.jpg">
+                        <h3><a href={% post_url 2017-03-03-discovering-Codurance-during-my-first-week-as-apprentice %}>{% t careers.become_an_apprentice.life_apprentice.first_week_title %}</a></h3>
+                        <p>At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum
+                        deleniti
+                        atque corrupti quos dolores.</p>
+                    </div>
+                </div>
+                <div class="col-md-4 md-margin-bottom-40">
+                    <div class="news-v1-in">
+                        <img class="img-responsive" alt="" src="/assets/img/custom/careers/ourpeople.jpg">
+                        <h3><a href="{% post_url 2017-05-19-my-first-year-at-codurance %}">{% t careers.become_an_apprentice.life_apprentice.first_year_title %}</a></h3>
+                        <p>At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum
+                        deleniti
+                        atque corrupti quos dolores.</p>
+                    </div>
+                </div>
+                <div class="col-md-4">
+                    <div class="news-v1-in">
+                        <img class="img-responsive" alt="" src="/assets/img/custom/careers/ourpeople.jpg">
+                        <h3><a href={% post_url 2017-04-03-learning-specification-by-example-from-gojko-adzic %}>{% t careers.become_an_apprentice.life_apprentice.learning_specification_title %}</a></h3>
+                        <p>At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum
+                        deleniti
+                        atque corrupti quos dolores.</p>
+                    </div>
+                </div>
             </div>
         </div>
-
-
-        <div> 
-          <div class="row content-boxes-v3 margin-bottom-20 margin-top-20 bg-grey">
-            <div class="col-sm-4 sm-margin-bottom-40">
-              <i class="icon-custom rounded-x icon-sm icon-bg-u fa fa-lightbulb-o"></i>
-              <div class="content-boxes-in-v3">
-                <h2 class="heading-sm">
-                  <span>{% t careers.become_a_apprentice.benefits.conf_title%}</span>
-                </h2>
-                <p>{% t careers.become_a_apprentice.benefits.conf_description %}</p>
-              </div>
-            </div>
-            <div class="col-sm-4 sm-margin-bottom-40">
-              <i class="icon-custom rounded-x icon-sm icon-bg-blue fa fa-bullhorn"></i>
-              <div class="content-boxes-in-v3">
-                <h2 class="heading-sm">
-                  <span>{% t careers.become_a_apprentice.benefits.training_title%}</span>
-                </h2>
-                <p>{% t careers.become_a_apprentice.benefits.training_description %}</p>
-              </div>
-            </div>
-            <div class="col-sm-4">
-              <i class="icon-custom rounded-x icon-sm icon-bg-red icon-line icon-rocket"></i>
-              <div class="content-boxes-in-v3">
-                <h2 class="heading-sm">
-                  <span>{% t careers.become_a_apprentice.benefits.books_title %}</span>
-                </h2>
-                <p>{% t careers.become_a_apprentice.benefits.books_description %}</p>
-              </div>
-            </div>
-          </div>
-
-
-          <div class="row">
-            <div class="heading heading-v4">
-              <h3>{% t careers.become_a_apprentice.benefits.culture_title %}</h3> 
-            </div>
-          </div>
-
-          <div class="row content-boxes-v3 margin-bottom-20 margin-top-20">
-            <div class="col-sm-4 sm-margin-bottom-40">
-              <i class="icon-custom rounded-x icon-sm icon-color-u fa fa-lightbulb-o"></i>
-              <div class="content-boxes-in-v3">
-                <h2 class="heading-sm">
-                  <span>{% t careers.become_a_apprentice.benefits.experts_title %}</span>
-                </h2>
-                <p>{% t careers.become_a_apprentice.benefits.experts_description %}</p>
-              </div>
-            </div>
-            <div class="col-sm-4 sm-margin-bottom-40 bg-grey">
-              <i class="icon-custom rounded-x icon-sm icon-color-blue fa fa-bullhorn"></i>
-              <div class="content-boxes-in-v3">
-                <h2 class="heading-sm">
-                  <span>{% t careers.become_a_apprentice.benefits.transparency_title %}</span>
-                </h2>
-                <p>{% t careers.become_a_apprentice.benefits.transparency_description %}</p>
-              </div>
-            </div>
-            <div class="col-sm-4">
-              <i class="icon-custom rounded-x icon-sm icon-color-red icon-line icon-rocket"></i>
-              <div class="content-boxes-in-v3">
-                <h2 class="heading-sm">
-                  <span>{% t careers.become_a_apprentice.benefits.autonomy_title %}</span>
-                </h2>
-                <p>{% t careers.become_a_apprentice.benefits.autonomy_description %}</p>
-              </div>
-            </div>
-          </div>
-
-
-          <div class="row">
-            <div class="heading heading-v4">
-              <h3>{% t careers.become_a_apprentice.benefits.lifestyle_title %}</h3> 
-            </div>
-          </div>
-
-          <div class="row content-boxes-v3 margin-bottom-40 margin-top-20">
-            <div class="col-sm-4 sm-margin-bottom-40">
-              <i class="icon-custom rounded-x icon-sm icon-color-u fa fa-lightbulb-o"></i>
-              <div class="content-boxes-in-v3">
-                <h2 class="heading-sm">
-                  <span>{% t careers.become_a_apprentice.benefits.holidays_title %}</span>
-                </h2>
-                <p>{% t careers.become_a_apprentice.benefits.holidays_description %}</p>
-              </div>
-            </div>
-            <div class="col-sm-4 sm-margin-bottom-40 bg-grey">
-              <i class="icon-custom rounded-x icon-sm icon-color-blue fa fa-bullhorn"></i>
-              <div class="content-boxes-in-v3">
-                <h2 class="heading-sm">
-                  <span>{% t careers.become_a_apprentice.benefits.pensions_title %}</span>
-                </h2>
-                <p>{% t careers.become_a_apprentice.benefits.pensions_description %}</p>
-              </div>
-            </div>
-            <div class="col-sm-4">
-              <i class="icon-custom rounded-x icon-sm icon-color-red icon-line icon-rocket"></i>
-              <div class="content-boxes-in-v3">
-                <h2 class="heading-sm">
-                  <span>{% t careers.become_a_apprentice.benefits.life_cover_title %}</span>
-                </h2>
-                <p>{% t careers.become_a_apprentice.benefits.life_cover_description %}</p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
     </div>
-    </div>
-  </div>
+</div>

--- a/careers/become_an_apprentice.html
+++ b/careers/become_an_apprentice.html
@@ -1,145 +1,194 @@
 ---
 layout: default
-title: Become an Apprentice
+title: Become a Apprentice
 ---
-
 <div class="breadcrumbs-v3 ourpeople">
     <div class="container text-center">
-        <h1>{% t careers.title %}</h1>
     </div>
 </div>
 
-<div class="container content">
-    <div class="row">
-        <div class="casestudy-quote">
-            <div class="quote-v3">
-                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse viverra mi sit amet orci
-                    venenatis aliquet
-                    sed sed nisi.</p>
-                <span>Name Surname, Software Craftsman <a href="/company"> Codurance</a></span>
-            </div>
-        </div>
-        <div class="col-md-12">
-            <div class="col-md-offset-3 col-md-6 text-center margin-top-10">
-                <h2>Apprenticeship program</h2>
-            </div>
-            <div class="col-md-3">
-                <a href="#" class="btn-u btn-u-lg btn-more">Become an Apprentice</a>
-            </div>
-        </div>
-    </div>
 
-    <div class="row">
-        <div class="col-md-12">
-            <div class="margin-bottom-40">
-                <div class="headline">
-                    <h2>Paragraph 1</h2>
-                </div>
-                <p>Ut tempor nibh elit. Cras ullamcorper placerat dictum. Morbi sit amet rhoncus nisl. Ut pharetra enim
-                    et vehicula
-                    euismod. Morbi tincidunt, ex ac tempor molestie, velit mi imperdiet arcu, sed finibus massa est
-                    fermentum
-                    nisl. Nunc pretium bibendum risus at tristique. Vivamus consequat ante nec tincidunt suscipit.
-                    Nullam
-                    dolor urna, eleifend sit amet vehicula nec, rutrum vitae ligula. Suspendisse et consectetur turpis,
-                    id
-                    bibendum massa. Morbi laoreet nisi ex.</p>
+		<div class="bg-color-light">
+			<div class="container content-md">
+				<div class="text-center margin-bottom-60">
+					<div class="row">
+						<div class="col-md-12">
+							<div class="col-md-offset-3 col-md-6 margin-top-10">
+								<h2 class="title-v2 title-center">{% t careers-become_a_apprentice.title %}</h2>
+							</div>
+							<div class="col-md-3">
+								<button class="btn btn-u btn-more" data-toggle="modal" data-target="#apprentice-form">{% t careers-become_a_apprentice.apply_title %}</button>
+							</div>
+						</div>
+					</div>
+
+					{% include apply_form.html title="Become an Apprentice" target="apprentice" %}
+
+					<p class="space-lg-hor">Our craftsmen are practitioners, teachers, mentors, and leaders. We will assess your expertise in the following areas to see if you are a fit for us, this will also help you understand if we are a fit for you.</p>
+				</div>
+
+				<div class="row margin-bottom-30">
+					<div class="col-sm-6 sm-margin-bottom-50 animated fadeIn wow" data-wow-duration="1.5s">
+						<div class="service-block-v8">
+							<i class="icon-bubbles"></i>
+							<div class="service-block-desc">
+								<h3> {% t careers.become_a_apprentice.practices_title %} </h3>
+								<p> {% t careers.become_a_apprentice.practices_description %}</p>
+							</div>
+						</div>
+					</div>
+					<div class="col-sm-6 sm-margin-bottom-20 animated fadeIn wow" data-wow-duration="1.5s" data-wow-delay=".3s">
+						<div class="service-block-v8">
+							<i class="icon-globe"></i>
+							<div class="service-block-desc">
+								<h3> {% t careers.become_a_apprentice.design_title %} </h3>
+								<p> {% t careers.become_a_apprentice.design_description %} </p>
+							</div>
+						</div>
+					</div>
+				</div>
+				<div class="row margin-bottom-30">
+					<div class="col-sm-6 sm-margin-bottom-50 animated fadeIn wow" data-wow-duration="1.5s">
+						<div class="service-block-v8">
+							<i class="icon-bubbles"></i>
+							<div class="service-block-desc">
+								<h3> {% t careers.become_a_apprentice.technology_stacks_title %} </h3>
+								<p> {% t careers.become_a_apprentice.technology_stacks_description %}</p>
+							</div>
+						</div>
+					</div>
+					<div class="col-sm-6 sm-margin-bottom-20 animated fadeIn wow" data-wow-duration="1.5s" data-wow-delay=".3s">
+						<div class="service-block-v8">
+							<i class="icon-globe"></i>
+							<div class="service-block-desc">
+								<h3> {% t careers.become_a_apprentice.personality_title %} </h3>
+								<p> {% t careers.become_a_apprentice.personality_description %} </p>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+
+    <div>
+      <div class="container content-md">
+
+        <h2 class="title-v2 title-center">{% t careers.become_a_apprentice.benefits.title %}</h2>
+        <p class="space-lg-hor">{% t careers.become_a_apprentice.benefits.description %}</p>
+
+        <div class="row">
+            <div class="heading heading-v4">
+              <h3>{% t careers.become_a_apprentice.benefits.learning_title%}</h3> 
             </div>
         </div>
-    </div>
-    <div class="row">
-        <div class="col-md-12">
-            <div class="margin-bottom-40">
-                <div class="headline">
-                    <h2>Paragraph 2</h2>
-                </div>
-                <p>Etiam porttitor orci et nisi sagittis, semper auctor nisl varius. Cras pharetra neque eget justo
-                    bibendum
-                    pellentesque. Nunc sit amet pharetra nibh, eget accumsan justo. Suspendisse hendrerit urna a magna
-                    pretium
-                    cursus. Aliquam dolor risus, mattis ac posuere sed, tristique nec turpis. Nunc bibendum ut risus ac
-                    eleifend.
-                    Curabitur molestie lectus lectus, nec laoreet magna blandit at. In hac habitasse platea dictumst. In
-                    ultrices, dui ac mollis euismod, ex sem tempus odio, eu suscipit lorem lorem eu ante. Donec vitae
-                    orci
-                    eget enim condimentum vestibulum ut eget nibh. Pellentesque laoreet dolor ac tincidunt elementum.
-                    Suspendisse
-                    a feugiat ante. Integer porttitor pellentesque leo, id maximus neque ultricies a.</p>
+
+
+        <div> 
+          <div class="row content-boxes-v3 margin-bottom-20 margin-top-20 bg-grey">
+            <div class="col-sm-4 sm-margin-bottom-40">
+              <i class="icon-custom rounded-x icon-sm icon-bg-u fa fa-lightbulb-o"></i>
+              <div class="content-boxes-in-v3">
+                <h2 class="heading-sm">
+                  <span>{% t careers.become_a_apprentice.benefits.conf_title%}</span>
+                </h2>
+                <p>{% t careers.become_a_apprentice.benefits.conf_description %}</p>
+              </div>
             </div>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-md-12">
-            <div class="margin-bottom-40">
-                <div class="headline">
-                    <h2>Paragraph 3</h2>
-                </div>
-                <p>Integer venenatis maximus est, eu laoreet tellus rutrum at. Pellentesque eu venenatis neque. Nulla
-                    suscipit
-                    nibh vel congue lobortis. Nam consectetur vitae nisi id vulputate. Maecenas mattis pellentesque
-                    augue.
-                    Sed ut urna in metus ullamcorper hendrerit et porttitor felis. Integer congue, lorem a molestie
-                    aliquet,
-                    leo leo feugiat nunc, semper mattis lectus erat nec odio. Etiam eget fringilla nisi, in ultricies
-                    nibh.</p>
+            <div class="col-sm-4 sm-margin-bottom-40">
+              <i class="icon-custom rounded-x icon-sm icon-bg-blue fa fa-bullhorn"></i>
+              <div class="content-boxes-in-v3">
+                <h2 class="heading-sm">
+                  <span>{% t careers.become_a_apprentice.benefits.training_title%}</span>
+                </h2>
+                <p>{% t careers.become_a_apprentice.benefits.training_description %}</p>
+              </div>
             </div>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-md-offset-9 col-md-3">
-            <a href="#" class="btn-u btn-u-lg btn-more">Become an Apprentice</a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-md-offset-3 col-md-6 text-center">
-            <h2>More about lorem ipsum</h2>
-        </div>
-    </div>
-    <div class="row news-v1">
-        <div class="col-md-4 md-margin-bottom-40">
-            <div class="news-v1-in">
-                <img class="img-responsive" alt="" src="/assets/img/custom/careers/ourpeople.jpg">
-                <h3><a href="#">Focused on helping our clients to build a successful business</a></h3>
-                <p>At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum
-                    deleniti
-                    atque corrupti quos dolores.</p>
-                <ul class="list-inline news-v1-info">
-                    <li><span>By</span> <a href="#">Kathy Reyes</a></li>
-                    <li>|</li>
-                    <li><i class="fa fa-clock-o"></i> July 02, 2014</li>
-                    <li class="pull-right"><a href="#"><i class="fa fa-comments-o"></i> 14</a></li>
-                </ul>
+            <div class="col-sm-4">
+              <i class="icon-custom rounded-x icon-sm icon-bg-red icon-line icon-rocket"></i>
+              <div class="content-boxes-in-v3">
+                <h2 class="heading-sm">
+                  <span>{% t careers.become_a_apprentice.benefits.books_title %}</span>
+                </h2>
+                <p>{% t careers.become_a_apprentice.benefits.books_description %}</p>
+              </div>
             </div>
-        </div>
-        <div class="col-md-4 md-margin-bottom-40">
-            <div class="news-v1-in">
-                <img class="img-responsive" alt="" src="/assets/img/custom/careers/ourpeople.jpg">
-                <h3><a href="#">We build your website to realise your vision and best product</a></h3>
-                <p>At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum
-                    deleniti
-                    atque corrupti quos dolores.</p>
-                <ul class="list-inline news-v1-info">
-                    <li><span>By</span> <a href="#">John Clarck</a></li>
-                    <li>|</li>
-                    <li><i class="fa fa-clock-o"></i> July 02, 2014</li>
-                    <li class="pull-right"><a href="#"><i class="fa fa-comments-o"></i> 07</a></li>
-                </ul>
+          </div>
+
+
+          <div class="row">
+            <div class="heading heading-v4">
+              <h3>{% t careers.become_a_apprentice.benefits.culture_title %}</h3> 
             </div>
-        </div>
-        <div class="col-md-4">
-            <div class="news-v1-in">
-                <img class="img-responsive" alt="" src="/assets/img/custom/careers/ourpeople.jpg">
-                <h3><a href="#">Focused on helping our clients to build a successful business</a></h3>
-                <p>At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum
-                    deleniti
-                    atque corrupti quos dolores.</p>
-                <ul class="list-inline news-v1-info">
-                    <li><span>By</span> <a href="#">Tina Kruiger</a></li>
-                    <li>|</li>
-                    <li><i class="fa fa-clock-o"></i> July 02, 2014</li>
-                    <li class="pull-right"><a href="#"><i class="fa fa-comments-o"></i> 22</a></li>
-                </ul>
+          </div>
+
+          <div class="row content-boxes-v3 margin-bottom-20 margin-top-20">
+            <div class="col-sm-4 sm-margin-bottom-40">
+              <i class="icon-custom rounded-x icon-sm icon-color-u fa fa-lightbulb-o"></i>
+              <div class="content-boxes-in-v3">
+                <h2 class="heading-sm">
+                  <span>{% t careers.become_a_apprentice.benefits.experts_title %}</span>
+                </h2>
+                <p>{% t careers.become_a_apprentice.benefits.experts_description %}</p>
+              </div>
             </div>
+            <div class="col-sm-4 sm-margin-bottom-40 bg-grey">
+              <i class="icon-custom rounded-x icon-sm icon-color-blue fa fa-bullhorn"></i>
+              <div class="content-boxes-in-v3">
+                <h2 class="heading-sm">
+                  <span>{% t careers.become_a_apprentice.benefits.transparency_title %}</span>
+                </h2>
+                <p>{% t careers.become_a_apprentice.benefits.transparency_description %}</p>
+              </div>
+            </div>
+            <div class="col-sm-4">
+              <i class="icon-custom rounded-x icon-sm icon-color-red icon-line icon-rocket"></i>
+              <div class="content-boxes-in-v3">
+                <h2 class="heading-sm">
+                  <span>{% t careers.become_a_apprentice.benefits.autonomy_title %}</span>
+                </h2>
+                <p>{% t careers.become_a_apprentice.benefits.autonomy_description %}</p>
+              </div>
+            </div>
+          </div>
+
+
+          <div class="row">
+            <div class="heading heading-v4">
+              <h3>{% t careers.become_a_apprentice.benefits.lifestyle_title %}</h3> 
+            </div>
+          </div>
+
+          <div class="row content-boxes-v3 margin-bottom-40 margin-top-20">
+            <div class="col-sm-4 sm-margin-bottom-40">
+              <i class="icon-custom rounded-x icon-sm icon-color-u fa fa-lightbulb-o"></i>
+              <div class="content-boxes-in-v3">
+                <h2 class="heading-sm">
+                  <span>{% t careers.become_a_apprentice.benefits.holidays_title %}</span>
+                </h2>
+                <p>{% t careers.become_a_apprentice.benefits.holidays_description %}</p>
+              </div>
+            </div>
+            <div class="col-sm-4 sm-margin-bottom-40 bg-grey">
+              <i class="icon-custom rounded-x icon-sm icon-color-blue fa fa-bullhorn"></i>
+              <div class="content-boxes-in-v3">
+                <h2 class="heading-sm">
+                  <span>{% t careers.become_a_apprentice.benefits.pensions_title %}</span>
+                </h2>
+                <p>{% t careers.become_a_apprentice.benefits.pensions_description %}</p>
+              </div>
+            </div>
+            <div class="col-sm-4">
+              <i class="icon-custom rounded-x icon-sm icon-color-red icon-line icon-rocket"></i>
+              <div class="content-boxes-in-v3">
+                <h2 class="heading-sm">
+                  <span>{% t careers.become_a_apprentice.benefits.life_cover_title %}</span>
+                </h2>
+                <p>{% t careers.become_a_apprentice.benefits.life_cover_description %}</p>
+              </div>
+            </div>
+          </div>
         </div>
+      </div>
     </div>
-</div>
+    </div>
+  </div>

--- a/careers/become_an_apprentice.html
+++ b/careers/become_an_apprentice.html
@@ -25,198 +25,195 @@ title: Become an Apprentice
             {% include apply_form.html title="Become an Apprentice" target="apprentice" %}
 
             <p class="space-lg-hor">{% t careers.become_an_apprentice.description %}</p>
-		</div>
-		<div class="row margin-bottom-30">
-			<div class="col-sm-6 sm-margin-bottom-50 animated fadeIn wow" data-wow-duration="1.5s">
-				<div class="service-block-v8">
-					<i class="icon-bubbles"></i>
-					<div class="service-block-desc">
-						<h3> {% t careers.become_an_apprentice.how_works_title %} </h3>
-						<p> {% t careers.become_an_apprentice.how_works_description %}</p>
-					</div>
-				</div>
-			</div>
-			<div class="col-sm-6 sm-margin-bottom-20 animated fadeIn wow" data-wow-duration="1.5s" data-wow-delay=".3s">
-				<div class="service-block-v8">
-					<i class="icon-globe"></i>
-					<div class="service-block-desc">
-						<h3> {% t careers.become_an_apprentice.how_long_title %} </h3>
-						<p> {% t careers.become_an_apprentice.how_long_description %} </p>
-					</div>
-				</div>
-			</div>
-		</div>
-		<div class="row margin-bottom-30">
-			<div class="col-sm-6 sm-margin-bottom-50 animated fadeIn wow" data-wow-duration="1.5s">
-				<div class="service-block-v8">
-					<i class="icon-bubbles"></i>
-					<div class="service-block-desc">
-						<h3> {% t careers.become_an_apprentice.background_title %} </h3>
-						<p> {% t careers.become_an_apprentice.background_description %}</p>
-					</div>
-				</div>
-			</div>
-			<div class="col-sm-6 sm-margin-bottom-20 animated fadeIn wow" data-wow-duration="1.5s" data-wow-delay=".3s">
-				<div class="service-block-v8">
-					<i class="icon-globe"></i>
-					<div class="service-block-desc">
-						<h3> {% t careers.become_an_apprentice.is_it_for_me_title %} </h3>
-						<p> {% t careers.become_an_apprentice.is_it_for_me_description %} </p>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
+        </div>
+        <div class="row margin-bottom-30">
+            <div class="col-sm-6 sm-margin-bottom-50 animated fadeIn wow" data-wow-duration="1.5s">
+                <div class="service-block-v8">
+                    <i class="icon-bubbles"></i>
+                    <div class="service-block-desc">
+                        <h3> {% t careers.become_an_apprentice.how_works_title %} </h3>
+                        <p> {% t careers.become_an_apprentice.how_works_description %}</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-6 sm-margin-bottom-20 animated fadeIn wow" data-wow-duration="1.5s" data-wow-delay=".3s">
+                <div class="service-block-v8">
+                    <i class="icon-globe"></i>
+                    <div class="service-block-desc">
+                        <h3> {% t careers.become_an_apprentice.how_long_title %} </h3>
+                        <p> {% t careers.become_an_apprentice.how_long_description %} </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="row margin-bottom-30">
+            <div class="col-sm-6 sm-margin-bottom-50 animated fadeIn wow" data-wow-duration="1.5s">
+                <div class="service-block-v8">
+                    <i class="icon-bubbles"></i>
+                    <div class="service-block-desc">
+                        <h3> {% t careers.become_an_apprentice.background_title %} </h3>
+                        <p> {% t careers.become_an_apprentice.background_description %}</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-6 sm-margin-bottom-20 animated fadeIn wow" data-wow-duration="1.5s" data-wow-delay=".3s">
+                <div class="service-block-v8">
+                    <i class="icon-globe"></i>
+                    <div class="service-block-desc">
+                        <h3> {% t careers.become_an_apprentice.is_it_for_me_title %} </h3>
+                        <p> {% t careers.become_an_apprentice.is_it_for_me_description %} </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 <div>
-	<div class="container content-md">
+    <div class="container content-md">
 
-		<h2 class="title-v2 title-center">{% t careers.benefits.title %}</h2>
-		<p class="space-lg-hor">{% t careers.benefits.description %}</p>
+        <h2 class="title-v2 title-center">{% t careers.benefits.title %}</h2>
+        <p class="space-lg-hor">{% t careers.benefits.description %}</p>
 
-		<div class="row">
-			<div class="heading heading-v4">
-				<h3>{% t careers.benefits.learning_title%}</h3> 
-			</div>
-		</div>
+        <div class="row">
+            <div class="heading heading-v4">
+                <h3>{% t careers.benefits.learning_title%}</h3> 
+            </div>
+        </div>
 
+        <div> 
+            <div class="row content-boxes-v3 margin-bottom-20 margin-top-20">
+                <div class="col-sm-4 sm-margin-bottom-40">
+                    <i class="icon-custom rounded-x icon-sm icon-bg-u fa fa-lightbulb-o"></i>
+                    <div class="content-boxes-in-v3">
+                        <h2 class="heading-sm">
+                            <span>{% t careers.benefits.mentor_title%}</span>
+                        </h2>
+                        <p>{% t careers.benefits.mentor_description %}</p>
+                    </div>
+                </div>
+                <div class="col-sm-4 sm-margin-bottom-40 bg-grey">
+                    <i class="icon-custom rounded-x icon-sm icon-bg-blue fa fa-bullhorn"></i>
+                    <div class="content-boxes-in-v3">
+                        <h2 class="heading-sm">
+                            <span>{% t careers.benefits.training_title%}</span>
+                        </h2>
+                        <p>{% t careers.benefits.training_description %}</p>
+                    </div>
+                </div>
+                <div class="col-sm-4">
+                    <i class="icon-custom rounded-x icon-sm icon-bg-red icon-line icon-rocket"></i>
+                    <div class="content-boxes-in-v3">
+                        <h2 class="heading-sm">
+                            <span>{% t careers.benefits.books_title %}</span>
+                        </h2>
+                        <p>{% t careers.benefits.books_description %}</p>
+                    </div>
+                </div>
+            </div>
 
-		<div> 
-			<div class="row content-boxes-v3 margin-bottom-20 margin-top-20">
-				<div class="col-sm-4 sm-margin-bottom-40">
-					<i class="icon-custom rounded-x icon-sm icon-bg-u fa fa-lightbulb-o"></i>
-					<div class="content-boxes-in-v3">
-						<h2 class="heading-sm">
-							<span>{% t careers.benefits.mentor_title%}</span>
-						</h2>
-						<p>{% t careers.benefits.mentor_description %}</p>
-					</div>
-				</div>
-				<div class="col-sm-4 sm-margin-bottom-40 bg-grey">
-					<i class="icon-custom rounded-x icon-sm icon-bg-blue fa fa-bullhorn"></i>
-					<div class="content-boxes-in-v3">
-						<h2 class="heading-sm">
-							<span>{% t careers.benefits.training_title%}</span>
-						</h2>
-						<p>{% t careers.benefits.training_description %}</p>
-					</div>
-				</div>
-				<div class="col-sm-4">
-					<i class="icon-custom rounded-x icon-sm icon-bg-red icon-line icon-rocket"></i>
-					<div class="content-boxes-in-v3">
-						<h2 class="heading-sm">
-							<span>{% t careers.benefits.books_title %}</span>
-						</h2>
-						<p>{% t careers.benefits.books_description %}</p>
-					</div>
-				</div>
-			</div>
+            <div class="row">
+                <div class="heading heading-v4">
+                    <h3>{% t careers.benefits.culture_title %}</h3> 
+                </div>
+            </div>
 
+            <div class="row content-boxes-v3 margin-bottom-20 margin-top-20">
+                <div class="col-sm-4 sm-margin-bottom-40">
+                    <i class="icon-custom rounded-x icon-sm icon-color-u fa fa-lightbulb-o"></i>
+                    <div class="content-boxes-in-v3">
+                        <h2 class="heading-sm">
+                            <span>{% t careers.benefits.experts_title %}</span>
+                        </h2>
+                        <p>{% t careers.benefits.experts_description %}</p>
+                    </div>
+                </div>
+                <div class="col-sm-4 sm-margin-bottom-40 bg-grey">
+                    <i class="icon-custom rounded-x icon-sm icon-color-blue fa fa-bullhorn"></i>
+                    <div class="content-boxes-in-v3">
+                        <h2 class="heading-sm">
+                            <span>{% t careers.benefits.transparency_title %}</span>
+                        </h2>
+                        <p>{% t careers.benefits.transparency_description %}</p>
+                    </div>
+                </div>
+                <div class="col-sm-4">
+                    <i class="icon-custom rounded-x icon-sm icon-color-red icon-line icon-rocket"></i>
+                    <div class="content-boxes-in-v3">
+                        <h2 class="heading-sm">
+                            <span>{% t careers.benefits.autonomy_title %}</span>
+                        </h2>
+                        <p>{% t careers.benefits.autonomy_description %}</p>
+                    </div>
+                </div>
+            </div>
 
-			<div class="row">
-				<div class="heading heading-v4">
-					<h3>{% t careers.benefits.culture_title %}</h3> 
-				</div>
-			</div>
+            <div class="row">
+                <div class="heading heading-v4">
+                    <h3>{% t careers.benefits.lifestyle_title %}</h3> 
+                </div>
+            </div>
 
-			<div class="row content-boxes-v3 margin-bottom-20 margin-top-20">
-				<div class="col-sm-4 sm-margin-bottom-40">
-					<i class="icon-custom rounded-x icon-sm icon-color-u fa fa-lightbulb-o"></i>
-					<div class="content-boxes-in-v3">
-						<h2 class="heading-sm">
-							<span>{% t careers.benefits.experts_title %}</span>
-						</h2>
-						<p>{% t careers.benefits.experts_description %}</p>
-					</div>
-				</div>
-				<div class="col-sm-4 sm-margin-bottom-40 bg-grey">
-					<i class="icon-custom rounded-x icon-sm icon-color-blue fa fa-bullhorn"></i>
-					<div class="content-boxes-in-v3">
-						<h2 class="heading-sm">
-							<span>{% t careers.benefits.transparency_title %}</span>
-						</h2>
-						<p>{% t careers.benefits.transparency_description %}</p>
-					</div>
-				</div>
-				<div class="col-sm-4">
-					<i class="icon-custom rounded-x icon-sm icon-color-red icon-line icon-rocket"></i>
-					<div class="content-boxes-in-v3">
-						<h2 class="heading-sm">
-							<span>{% t careers.benefits.autonomy_title %}</span>
-						</h2>
-						<p>{% t careers.benefits.autonomy_description %}</p>
-					</div>
-				</div>
-			</div>
-
-
-			<div class="row">
-				<div class="heading heading-v4">
-					<h3>{% t careers.benefits.lifestyle_title %}</h3> 
-				</div>
-			</div>
-
-			<div class="row content-boxes-v3 margin-bottom-40 margin-top-20">
-				<div class="col-sm-4 sm-margin-bottom-40">
-					<i class="icon-custom rounded-x icon-sm icon-color-u fa fa-lightbulb-o"></i>
-					<div class="content-boxes-in-v3">
-						<h2 class="heading-sm">
-							<span>{% t careers.benefits.holidays_title %}</span>
-						</h2>
-						<p>{% t careers.benefits.holidays_description %}</p>
-					</div>
-				</div>
-				<div class="col-sm-4 sm-margin-bottom-40 bg-grey">
-					<i class="icon-custom rounded-x icon-sm icon-color-blue fa fa-bullhorn"></i>
-					<div class="content-boxes-in-v3">
-						<h2 class="heading-sm">
-							<span>{% t careers.benefits.pensions_title %}</span>
-						</h2>
-						<p>{% t careers.benefits.pensions_description %}</p>
-					</div>
-				</div>
-				<div class="col-sm-4">
-					<i class="icon-custom rounded-x icon-sm icon-color-red icon-line icon-rocket"></i>
-					<div class="content-boxes-in-v3">
-						<h2 class="heading-sm">
-							<span>{% t careers.benefits.life_cover_title %}</span>
-						</h2>
-						<p>{% t careers.benefits.life_cover_description %}</p>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
+            <div class="row content-boxes-v3 margin-bottom-40 margin-top-20">
+                <div class="col-sm-4 sm-margin-bottom-40">
+                    <i class="icon-custom rounded-x icon-sm icon-color-u fa fa-lightbulb-o"></i>
+                    <div class="content-boxes-in-v3">
+                        <h2 class="heading-sm">
+                            <span>{% t careers.benefits.holidays_title %}</span>
+                        </h2>
+                        <p>{% t careers.benefits.holidays_description %}</p>
+                    </div>
+                </div>
+                <div class="col-sm-4 sm-margin-bottom-40 bg-grey">
+                    <i class="icon-custom rounded-x icon-sm icon-color-blue fa fa-bullhorn"></i>
+                    <div class="content-boxes-in-v3">
+                        <h2 class="heading-sm">
+                            <span>{% t careers.benefits.pensions_title %}</span>
+                        </h2>
+                        <p>{% t careers.benefits.pensions_description %}</p>
+                    </div>
+                </div>
+                <div class="col-sm-4">
+                    <i class="icon-custom rounded-x icon-sm icon-color-red icon-line icon-rocket"></i>
+                    <div class="content-boxes-in-v3">
+                        <h2 class="heading-sm">
+                            <span>{% t careers.benefits.life_cover_title %}</span>
+                        </h2>
+                        <p>{% t careers.benefits.life_cover_description %}</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 
 <div class="bg-color-light">
     <div class="container content-md">
-		<div class="row">
-			<div class="col-md-offset-3 col-md-6 text-center">
-				<h2>{% t careers.become_an_apprentice.life_apprentice.title %}</h2>
-				<p>{% t careers.become_an_apprentice.life_apprentice.description  %}</p>
-			</div>
-		</div>
-		<div class="row news-v1">
-			{% assign first_week = site.posts | where:"name","Discovering Codurance during my first week as an apprentice" %}
-			{% assign first_year = site.posts | where:"name","my-first-year-at-codurance" %}
-			{% assign learning_specification = site.posts | where:"name","Learning Specification By Example from Gojko Adzic" %}
-                        {% if first_week[0] %}
-                            {% include life_of_apprentice_articles.html param=first_week truncated=2 %}
-                        {% endif %}
-                        {% if first_year[0] %}
-                            {% include life_of_apprentice_articles.html param=first_year truncated=5 %}
-                        {% endif %}
-                        {% if learning_specification[0] %}
-                            {% include life_of_apprentice_articles.html param=learning_specification truncated=2 %}
-                        {% endif %}
-		</div>
-		<div class="row">
-			<div class="col-md-12">
-				<div class="col-md-3 col-md-offset-9">
-					<button class="btn btn-u btn-more" data-toggle="modal" data-target="#apprentice-form">{% t careers.become_an_apprentice.apply_title %}</button>
-				</div>
-			</div>
-		</div>
-	</div>
+        <div class="row">
+            <div class="col-md-offset-3 col-md-6 text-center">
+                <h2>{% t careers.become_an_apprentice.life_apprentice.title %}</h2>
+                <p>{% t careers.become_an_apprentice.life_apprentice.description  %}</p>
+            </div>
+        </div>
+        <div class="row news-v1">
+            {% assign first_week = site.posts | where:"name","Discovering Codurance during my first week as an apprentice" %}
+            {% assign first_year = site.posts | where:"name","my-first-year-at-codurance" %}
+            {% assign learning_specification = site.posts | where:"name","Learning Specification By Example from Gojko Adzic" %}
+            {% if first_week[0] %}
+                {% include life_of_apprentice_articles.html param=first_week truncated=2 %}
+            {% endif %}
+            {% if first_year[0] %}
+                {% include life_of_apprentice_articles.html param=first_year truncated=5 %}
+            {% endif %}
+            {% if learning_specification[0] %}
+                {% include life_of_apprentice_articles.html param=learning_specification truncated=2 %}
+            {% endif %}
+        </div>
+        <div class="row">
+            <div class="col-md-12">
+                <div class="col-md-3 col-md-offset-9">
+                    <button class="btn btn-u btn-more" data-toggle="modal" data-target="#apprentice-form">{% t careers.become_an_apprentice.apply_title %}</button>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>

--- a/careers/become_an_apprentice.html
+++ b/careers/become_an_apprentice.html
@@ -25,58 +25,192 @@ title: Become an Apprentice
             {% include apply_form.html title="Become an Apprentice" target="apprentice" %}
 
             <p class="space-lg-hor">{% t careers.become_an_apprentice.description %}</p>
+		</div>
+		<div class="row margin-bottom-30">
+			<div class="col-sm-6 sm-margin-bottom-50 animated fadeIn wow" data-wow-duration="1.5s">
+				<div class="service-block-v8">
+					<i class="icon-bubbles"></i>
+					<div class="service-block-desc">
+						<h3> {% t careers.become_an_apprentice.how_works_title %} </h3>
+						<p> {% t careers.become_an_apprentice.how_works_description %}</p>
+					</div>
+				</div>
+			</div>
+			<div class="col-sm-6 sm-margin-bottom-20 animated fadeIn wow" data-wow-duration="1.5s" data-wow-delay=".3s">
+				<div class="service-block-v8">
+					<i class="icon-globe"></i>
+					<div class="service-block-desc">
+						<h3> {% t careers.become_an_apprentice.how_long_title %} </h3>
+						<p> {% t careers.become_an_apprentice.how_long_description %} </p>
+					</div>
+				</div>
+			</div>
+		</div>
+		<div class="row margin-bottom-30">
+			<div class="col-sm-6 sm-margin-bottom-50 animated fadeIn wow" data-wow-duration="1.5s">
+				<div class="service-block-v8">
+					<i class="icon-bubbles"></i>
+					<div class="service-block-desc">
+						<h3> {% t careers.become_an_apprentice.background_title %} </h3>
+						<p> {% t careers.become_an_apprentice.background_description %}</p>
+					</div>
+				</div>
+			</div>
+			<div class="col-sm-6 sm-margin-bottom-20 animated fadeIn wow" data-wow-duration="1.5s" data-wow-delay=".3s">
+				<div class="service-block-v8">
+					<i class="icon-globe"></i>
+					<div class="service-block-desc">
+						<h3> {% t careers.become_an_apprentice.is_it_for_me_title %} </h3>
+						<p> {% t careers.become_an_apprentice.is_it_for_me_description %} </p>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+<div>
+	<div class="container content-md">
 
-            <div class="row">
-                <div class="col-md-12">
-                    <div class="margin-bottom-40">
-                        <div class="headline">
-                            <h2>{% t careers.become_an_apprentice.how_works_title%}</h2>
-                        </div>
-                        <p>{% t careers.become_an_apprentice.how_works_description%}</p>
-                    </div>
-                </div>
-            </div>
-            <div class="row">
-                <div class="col-md-12">
-                    <div class="margin-bottom-40">
-                        <div class="headline">
-                            <h2>{% t careers.become_an_apprentice.background_title%}</h2>
-                        </div>
-                        <p>{% t careers.become_an_apprentice.background_description%}</p>
-                    </div>
-                </div>
-            </div>
-            <div class="row">
-                <div class="col-md-12">
-                    <div class="margin-bottom-40">
-                        <div class="headline">
-                            <h2>{% t careers.become_an_apprentice.is_it_for_me_title%}</h2>
-                        </div>
-                        <p>{% t careers.become_an_apprentice.is_it_for_me_description%}</p>
-                    </div>
-                </div>
-            </div>
-            <div class="row">
-                <div class="col-md-offset-3 col-md-6 text-center">
-                    <h2>{% t careers.become_an_apprentice.life_apprentice.title %}</h2>
-                    <p>{% t careers.become_an_apprentice.life_apprentice.description  %}</p>
-                </div>
-            </div>
-            <div class="row news-v1">
-                {% assign first_week = site.posts | where:"name","Discovering Codurance during my first week as an apprentice" %}
-                {% include life_of_apprentice_articles.html param=first_week truncated=2 %}
-                {% assign first_year = site.posts | where:"name","my-first-year-at-codurance" %}
-                {% include life_of_apprentice_articles.html param=first_year truncated=5 %}
-                {% assign learning_specification = site.posts | where:"name","Learning Specification By Example from Gojko Adzic" %}
-                {% include life_of_apprentice_articles.html param=learning_specification truncated=2 %}
-            </div>
-        </div>
+		<h2 class="title-v2 title-center">{% t careers.benefits.title %}</h2>
+		<p class="space-lg-hor">{% t careers.benefits.description %}</p>
+
 		<div class="row">
-            <div class="col-md-12">
-                <div class="col-md-3 col-md-offset-9">
-                    <button class="btn btn-u btn-more" data-toggle="modal" data-target="#apprentice-form">{% t careers.become_an_apprentice.apply_title %}</button>
-                </div>
-            </div>
-        </div>
-    </div>
+			<div class="heading heading-v4">
+				<h3>{% t careers.benefits.learning_title%}</h3> 
+			</div>
+		</div>
+
+
+		<div> 
+			<div class="row content-boxes-v3 margin-bottom-20 margin-top-20">
+				<div class="col-sm-4 sm-margin-bottom-40">
+					<i class="icon-custom rounded-x icon-sm icon-bg-u fa fa-lightbulb-o"></i>
+					<div class="content-boxes-in-v3">
+						<h2 class="heading-sm">
+							<span>{% t careers.benefits.mentor_title%}</span>
+						</h2>
+						<p>{% t careers.benefits.mentor_description %}</p>
+					</div>
+				</div>
+				<div class="col-sm-4 sm-margin-bottom-40 bg-grey">
+					<i class="icon-custom rounded-x icon-sm icon-bg-blue fa fa-bullhorn"></i>
+					<div class="content-boxes-in-v3">
+						<h2 class="heading-sm">
+							<span>{% t careers.benefits.training_title%}</span>
+						</h2>
+						<p>{% t careers.benefits.training_description %}</p>
+					</div>
+				</div>
+				<div class="col-sm-4">
+					<i class="icon-custom rounded-x icon-sm icon-bg-red icon-line icon-rocket"></i>
+					<div class="content-boxes-in-v3">
+						<h2 class="heading-sm">
+							<span>{% t careers.benefits.books_title %}</span>
+						</h2>
+						<p>{% t careers.benefits.books_description %}</p>
+					</div>
+				</div>
+			</div>
+
+
+			<div class="row">
+				<div class="heading heading-v4">
+					<h3>{% t careers.benefits.culture_title %}</h3> 
+				</div>
+			</div>
+
+			<div class="row content-boxes-v3 margin-bottom-20 margin-top-20">
+				<div class="col-sm-4 sm-margin-bottom-40">
+					<i class="icon-custom rounded-x icon-sm icon-color-u fa fa-lightbulb-o"></i>
+					<div class="content-boxes-in-v3">
+						<h2 class="heading-sm">
+							<span>{% t careers.benefits.experts_title %}</span>
+						</h2>
+						<p>{% t careers.benefits.experts_description %}</p>
+					</div>
+				</div>
+				<div class="col-sm-4 sm-margin-bottom-40 bg-grey">
+					<i class="icon-custom rounded-x icon-sm icon-color-blue fa fa-bullhorn"></i>
+					<div class="content-boxes-in-v3">
+						<h2 class="heading-sm">
+							<span>{% t careers.benefits.transparency_title %}</span>
+						</h2>
+						<p>{% t careers.benefits.transparency_description %}</p>
+					</div>
+				</div>
+				<div class="col-sm-4">
+					<i class="icon-custom rounded-x icon-sm icon-color-red icon-line icon-rocket"></i>
+					<div class="content-boxes-in-v3">
+						<h2 class="heading-sm">
+							<span>{% t careers.benefits.autonomy_title %}</span>
+						</h2>
+						<p>{% t careers.benefits.autonomy_description %}</p>
+					</div>
+				</div>
+			</div>
+
+
+			<div class="row">
+				<div class="heading heading-v4">
+					<h3>{% t careers.benefits.lifestyle_title %}</h3> 
+				</div>
+			</div>
+
+			<div class="row content-boxes-v3 margin-bottom-40 margin-top-20">
+				<div class="col-sm-4 sm-margin-bottom-40">
+					<i class="icon-custom rounded-x icon-sm icon-color-u fa fa-lightbulb-o"></i>
+					<div class="content-boxes-in-v3">
+						<h2 class="heading-sm">
+							<span>{% t careers.benefits.holidays_title %}</span>
+						</h2>
+						<p>{% t careers.benefits.holidays_description %}</p>
+					</div>
+				</div>
+				<div class="col-sm-4 sm-margin-bottom-40 bg-grey">
+					<i class="icon-custom rounded-x icon-sm icon-color-blue fa fa-bullhorn"></i>
+					<div class="content-boxes-in-v3">
+						<h2 class="heading-sm">
+							<span>{% t careers.benefits.pensions_title %}</span>
+						</h2>
+						<p>{% t careers.benefits.pensions_description %}</p>
+					</div>
+				</div>
+				<div class="col-sm-4">
+					<i class="icon-custom rounded-x icon-sm icon-color-red icon-line icon-rocket"></i>
+					<div class="content-boxes-in-v3">
+						<h2 class="heading-sm">
+							<span>{% t careers.benefits.life_cover_title %}</span>
+						</h2>
+						<p>{% t careers.benefits.life_cover_description %}</p>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="bg-color-light">
+    <div class="container content-md">
+		<div class="row">
+			<div class="col-md-offset-3 col-md-6 text-center">
+				<h2>{% t careers.become_an_apprentice.life_apprentice.title %}</h2>
+				<p>{% t careers.become_an_apprentice.life_apprentice.description  %}</p>
+			</div>
+		</div>
+		<div class="row news-v1">
+			{% assign first_week = site.posts | where:"name","Discovering Codurance during my first week as an apprentice" %}
+			{% include life_of_apprentice_articles.html param=first_week truncated=2 %}
+			{% assign first_year = site.posts | where:"name","my-first-year-at-codurance" %}
+			{% include life_of_apprentice_articles.html param=first_year truncated=5 %}
+			{% assign learning_specification = site.posts | where:"name","Learning Specification By Example from Gojko Adzic" %}
+			{% include life_of_apprentice_articles.html param=learning_specification truncated=2 %}
+		</div>
+		<div class="row">
+			<div class="col-md-12">
+				<div class="col-md-3 col-md-offset-9">
+					<button class="btn btn-u btn-more" data-toggle="modal" data-target="#apprentice-form">{% t careers.become_an_apprentice.apply_title %}</button>
+				</div>
+			</div>
+		</div>
+	</div>
 </div>

--- a/careers/become_an_apprentice.html
+++ b/careers/become_an_apprentice.html
@@ -63,33 +63,12 @@ title: Become an Apprentice
                 </div>
             </div>
             <div class="row news-v1">
-                <div class="col-md-4 md-margin-bottom-40">
-                    <div class="news-v1-in">
-                        <img class="img-responsive" alt="" src="/assets/img/custom/careers/ourpeople.jpg">
-                        <h3><a href={% post_url 2017-03-03-discovering-Codurance-during-my-first-week-as-apprentice %}>{% t careers.become_an_apprentice.life_apprentice.first_week_title %}</a></h3>
-                        <p>At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum
-                        deleniti
-                        atque corrupti quos dolores.</p>
-                    </div>
-                </div>
-                <div class="col-md-4 md-margin-bottom-40">
-                    <div class="news-v1-in">
-                        <img class="img-responsive" alt="" src="/assets/img/custom/careers/ourpeople.jpg">
-                        <h3><a href="{% post_url 2017-05-19-my-first-year-at-codurance %}">{% t careers.become_an_apprentice.life_apprentice.first_year_title %}</a></h3>
-                        <p>At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum
-                        deleniti
-                        atque corrupti quos dolores.</p>
-                    </div>
-                </div>
-                <div class="col-md-4">
-                    <div class="news-v1-in">
-                        <img class="img-responsive" alt="" src="/assets/img/custom/careers/ourpeople.jpg">
-                        <h3><a href={% post_url 2017-04-03-learning-specification-by-example-from-gojko-adzic %}>{% t careers.become_an_apprentice.life_apprentice.learning_specification_title %}</a></h3>
-                        <p>At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum
-                        deleniti
-                        atque corrupti quos dolores.</p>
-                    </div>
-                </div>
+                {% assign first_week = site.posts | where:"name","Discovering Codurance during my first week as an apprentice" %}
+                {% include life_of_apprentice_articles.html param=first_week truncated=2 %}
+                {% assign first_year = site.posts | where:"name","my-first-year-at-codurance" %}
+                {% include life_of_apprentice_articles.html param=first_year truncated=5 %}
+                {% assign learning_specification = site.posts | where:"name","Learning Specification By Example from Gojko Adzic" %}
+                {% include life_of_apprentice_articles.html param=learning_specification truncated=2 %}
             </div>
         </div>
     </div>

--- a/careers/become_an_apprentice.html
+++ b/careers/become_an_apprentice.html
@@ -16,15 +16,21 @@ title: Become an Apprentice
                     <div class="col-md-offset-3 col-md-6 margin-top-10">
                         <h2 class="title-v2 title-center">{% t careers.become_an_apprentice.title %}</h2>
                     </div>
-                    <div class="col-md-3">
-                        <button class="btn btn-u btn-more" data-toggle="modal" data-target="#apprentice-form">{% t careers.become_an_apprentice.apply_title %}</button>
-                    </div>
                 </div>
             </div>
 
+            <div class="row">
+                <p class="space-lg-hor">{% t careers.become_an_apprentice.description %}</p>
+            </div>
+
+            <div class="row">
+                <div class="col-md-4 col-md-offset-4">
+                    <button class="btn btn-u btn-more" data-toggle="modal" data-target="#apprentice-form">{% t careers.become_an_apprentice.apply_title %}</button>
+                </div>
+            </div>
+ 
             {% include apply_form.html title="Become an Apprentice" target="apprentice" %}
 
-            <p class="space-lg-hor">{% t careers.become_an_apprentice.description %}</p>
         </div>
         <div class="row margin-bottom-30">
             <div class="col-sm-6 sm-margin-bottom-50 animated fadeIn wow" data-wow-duration="1.5s">
@@ -184,6 +190,13 @@ title: Become an Apprentice
                 </div>
             </div>
         </div>
+
+        <div class="row text-center">
+            <div class="col-md-4 col-md-offset-4">
+                <button class="btn btn-u btn-more" data-toggle="modal" data-target="#apprentice-form">{% t careers.become_an_apprentice.apply_title %}</button>
+            </div>
+        </div>
+
     </div>
 </div>
 
@@ -208,13 +221,6 @@ title: Become an Apprentice
             {% if learning_specification[0] %}
                 {% include life_of_apprentice_articles.html param=learning_specification truncated_title=2 truncated_abstract=30 %}
             {% endif %}
-        </div>
-        <div class="row">
-            <div class="col-md-12">
-                <div class="col-md-3 col-md-offset-9">
-                    <button class="btn btn-u btn-more" data-toggle="modal" data-target="#apprentice-form">{% t careers.become_an_apprentice.apply_title %}</button>
-                </div>
-            </div>
         </div>
     </div>
 </div>

--- a/careers/become_an_apprentice.html
+++ b/careers/become_an_apprentice.html
@@ -71,17 +71,18 @@ title: Become an Apprentice
 <div>
     <div class="container content-md">
 
-        <h2 class="title-v2 title-center">{% t careers.benefits.title %}</h2>
-        <p class="space-lg-hor">{% t careers.benefits.description %}</p>
-
-        <div class="row">
-            <div class="heading heading-v4">
-                <h3>{% t careers.benefits.learning_title%}</h3> 
-            </div>
+        <div class="margin-bottom-40">
+            <h2 class="title-v2 title-center">{% t careers.benefits.title %}</h2>
+            <p class="space-lg-hor">{% t careers.benefits.description %}</p>
         </div>
 
         <div> 
-            <div class="row content-boxes-v3 margin-bottom-20 margin-top-20">
+            <div class="row">
+                <div class="heading heading-v4">
+                    <h3>{% t careers.benefits.learning_title%}</h3> 
+                </div>
+            </div>
+            <div class="row content-boxes-v3 margin-bottom-40 margin-top-20">
                 <div class="col-sm-4 sm-margin-bottom-40">
                     <i class="icon-custom rounded-x icon-sm icon-bg-u fa fa-lightbulb-o"></i>
                     <div class="content-boxes-in-v3">
@@ -117,7 +118,7 @@ title: Become an Apprentice
                 </div>
             </div>
 
-            <div class="row content-boxes-v3 margin-bottom-20 margin-top-20">
+            <div class="row content-boxes-v3 margin-bottom-40 margin-top-20">
                 <div class="col-sm-4 sm-margin-bottom-40">
                     <i class="icon-custom rounded-x icon-sm icon-color-u fa fa-lightbulb-o"></i>
                     <div class="content-boxes-in-v3">
@@ -189,7 +190,7 @@ title: Become an Apprentice
 <div class="bg-color-light">
     <div class="container content-md">
         <div class="row">
-            <div class="col-md-offset-3 col-md-6 text-center">
+            <div class="col-md-offset-2 col-md-8 text-center margin-bottom-40">
                 <h2>{% t careers.become_an_apprentice.life_apprentice.title %}</h2>
                 <p>{% t careers.become_an_apprentice.life_apprentice.description  %}</p>
             </div>

--- a/careers/index.html
+++ b/careers/index.html
@@ -20,32 +20,16 @@ title: Careers
             <div class="service-block-v7">
                 <i class="icon-diamond"></i>
                 <h3 class="title-v3-bg text-uppercase">{% t careers-become_a_craftsman.title %}</h3>
-                <div class="equal-height-column margin-bottom-10">
-                  <p>We are a company formed by craftswomen and craftsmen who care about the quality of the work we do.</p>
-                  
-                  <p><strong>What is important to us?</strong> We are looking for talented people who share our passion for writing well-crafted software and believe in the principles and values of Software Craftmanship, Exreme Programming and Agile software development. In addition, good communication skills, willingness to learn and work with different technology stacks, and confidence to express ideas are important.</p> 
-
-                  <p><strong>What background do I need to have?</strong> You are a practitioner of Agile/Lean processes and Extreme Programming Practices, specifically TDD, CI, and Simple Design. Your prefer a DevOps culture and value Continuous Deployment/Delivery. You have appreciation for Software Design both at macro and micro levels and naturally follow Clean Code principles. You understand architectural concerns relating to performance, security, logging, monitoring, and operations. Good communication skills essential to our work. </p> 
-                  
-                  <p><strong>What technolgies do we use?</strong> Currently, the three main technology platforms we use are <strong>JVM (Java, Clojure, Scala), .Net (C#, F#), and NodeJS</strong>. We use Amazon AWS or Azure as our preferred cloud solutions. We expect our Craftsmen to have a good grasp of front-end technologies based on HTML, CSS, and Javascript. 
-                  </p>
-                </div>
-                <button class="btn btn-u btn-more" data-toggle="modal" data-target="#craftsman-form" >{% t careers-become_a_craftsman.link_title %}</button>
+                <div class="equal-height-column margin-bottom-10">{% t careers-become_a_craftsman.description %}</div>
+                <a href="{{ '/careers/become_a_craftsman' | prepend: site.baseurl }}" role="button" class="btn btn-u btn-more">{% t careers-become_a_craftsman.more_info %}</a>
             </div>
         </div>
         <div class="col-md-6">
             <div class="service-block-v7">
                 <i class="icon-graduation"></i>
                 <h3 class="title-v3-bg text-uppercase">{% t careers-become_an_apprentice.title %}</h3>
-                <div class="equal-height-column margin-bottom-10">
-                  <p>Our apprentices share our passion for creating well-crafted software, but have not yet had the suitable learning opportunities to refine their craft.</p>
-
-                  <p><strong>How does it work?</strong> The priority is for you to acquire the basic set of skills necessary to become recognised, as software craftsman, by the rest of the company. You will choose a mentor from our craftsmen who will help understand your strengths and weaknesses based on the core set. The mentor will guide you through your apprenticeship which we expect to be a maximum of 6 months. There is no exam in the end - when your mentor is convinced and can convince at least 3 other craftsmen then you graduate.</p>
-                  <p><strong>What background do I need to have?</strong> You are a productive developer in the language of your choice on the JVM, .NET, and/or Node JS platforms. You know of Agile processes and practices and can apply them and are looking to become an expert in reasoning about them. You have basic knowledge of micro level and macro level design. </p>
-                  <p><strong>Is this the programme for me?</strong> If you have a passion for learning and are ready for a chance to learn technologies and practices needed to become a Software Craftsman under the guidance of a dedicated mentor then we look forward to receiving your application.</p>
-                </div>
-                
-                <button class="btn btn-u btn-more" data-toggle="modal" data-target="#apprentice-form">{% t careers-become_an_apprentice.link_title %}</a>
+                <div class="equal-height-column margin-bottom-10">{% t careers-become_an_apprentice.description %}</div>
+                <a href="{{ '/careers/become_an_apprentice' | prepend: site.baseurl }}" role="button" class="btn btn-u btn-more">{% t careers-become_an_apprentice.more_info %}</a>
             </div>
         </div>
     </div>

--- a/careers/index.html
+++ b/careers/index.html
@@ -34,9 +34,6 @@ title: Careers
         </div>
     </div>
 
-    {% include apply_form.html title="Become a Craftsman" target="craftsman" %}
-    {% include apply_form.html title="Become an Apprentice" target="apprentice" %}
-
     <div class="row">
         <div class="col-md-12">
             <div class="heading heading-v4 margin-bottom-20">


### PR DESCRIPTION
### Not ready for merge

Continuing the branch created by @mashooq, this PR:

- [x] Replace the `Apply` buttons on the Careers page with links to the Apprentice and Craftsman pages;
- [x] Add the Application Form buttons to Apprentice / Craftsman pages;
- [x] Add the proper content to the Apprentice page;

The Application Form used in this PR is the same as the currently live version. The new Application Form will be implemented in a future iteration.