### PR TITLE
Fixing ALL-AUTHOR-POSTS button

### DIFF
--- a/_includes/publication.html
+++ b/_includes/publication.html
@@ -97,7 +97,7 @@
             <div class="media-body">
               <h4 class="h5 g-color-black g-font-weight-600">{{ page.author | author_links}}</h4>
               <p class="g-color-gray-dark-v5 mb-4">{{ member.fullDescription }}</p>
-              <a class="btn u-btn-outline-black g-brd-gray-light-v1 g-font-weight-600 g-font-size-12 text-uppercase g-py-12 g-px-25" href="{{ site.baseurl }}/publications/author/{{ page.author | replace: ' ', '-' | downcase }}">All author posts</a>
+              <a class="btn u-btn-outline-black g-brd-gray-light-v1 g-font-weight-600 g-font-size-12 text-uppercase g-py-12 g-px-25" href="{{ page.author | author_url }}">All author posts</a>
             </div>
           </div>
         </div>

--- a/_plugins/author_generator.rb
+++ b/_plugins/author_generator.rb
@@ -114,15 +114,12 @@ module Jekyll
     # Returns string
     #
     def author_links(authors)
-      dir = @context.registers[:site].config['author_dir'] || "authors"
-      baseurl = @context.registers[:site].config['baseurl']
       if String.try_convert(authors)
                authors = [ authors ]
       end
       authors = authors.map do |author|
-        author_dir = author.downcase
-        author_dir [" "] = "-"
-        "<a class='author' href='#{baseurl}/#{dir}/#{author_dir}/'>#{author}</a>"
+        author_url = author_url(author)
+        "<a class='author' href='#{author_url}'>#{author}</a>"
       end
       case authors.length
       when 0
@@ -132,6 +129,14 @@ module Jekyll
       else
         "#{authors[0...-1].join(', ')}, #{authors[-1]}"
       end
+    end
+
+    def author_url(author)
+        basedir = @context.registers[:site].config['author_dir'] || "authors"
+        baseurl = @context.registers[:site].config['baseurl']
+        dir = author.downcase
+        dir [" "] = "-"
+        "#{baseurl}/#{basedir}/#{dir}/"
     end
 
     # Outputs the post.date as formatted html, with hooks for CSS styling.


### PR DESCRIPTION
Fixing ALL-AUTHOR-POSTS button when author name is composed by more than 2 parts