### PR TITLE
Fix Author's URL

### DIFF
--- a/_plugins/author_generator.rb
+++ b/_plugins/author_generator.rb
@@ -76,7 +76,7 @@ module Jekyll
                post_authors = [ post_authors ]
           end
           post_authors.each do |author|
-            author_dir = author.downcase.gsub(" ", "-")
+            author_dir = AuthorNameToPath.parse(author)
             self.write_author_index(File.join(dir, author_dir), author)
           end
         end
@@ -133,7 +133,7 @@ module Jekyll
     def author_url(author)
         basedir = @context.registers[:site].config['author_dir'] || "authors"
         baseurl = @context.registers[:site].config['baseurl']
-        author_dir = author.downcase.gsub(" ", "-")
+        author_dir = AuthorNameToPath.parse(author)
 
         "#{baseurl}/#{basedir}/#{author_dir}/"
     end
@@ -150,6 +150,12 @@ module Jekyll
       result
     end
 
+  end
+
+  module AuthorNameToPath
+    def self.parse(name)
+        name.downcase.gsub(" ", "-")
+    end
   end
 
 end

--- a/_plugins/author_generator.rb
+++ b/_plugins/author_generator.rb
@@ -76,8 +76,7 @@ module Jekyll
                post_authors = [ post_authors ]
           end
           post_authors.each do |author|
-            author_dir = author.downcase
-            author_dir[" "] = "-"
+            author_dir = author.downcase.gsub(" ", "-")
             self.write_author_index(File.join(dir, author_dir), author)
           end
         end
@@ -134,9 +133,9 @@ module Jekyll
     def author_url(author)
         basedir = @context.registers[:site].config['author_dir'] || "authors"
         baseurl = @context.registers[:site].config['baseurl']
-        dir = author.downcase
-        dir [" "] = "-"
-        "#{baseurl}/#{basedir}/#{dir}/"
+        author_dir = author.downcase.gsub(" ", "-")
+
+        "#{baseurl}/#{basedir}/#{author_dir}/"
     end
 
     # Outputs the post.date as formatted html, with hooks for CSS styling.


### PR DESCRIPTION
Currently, if an author's name is composed of more than two words, the URL generated will have the pattern `first-second%20third`, that is, only the first empty space will be replaced with a dash.
The correct form should be `first-second-third`

## Testing:

1. Visit https://codurance.com/publications/author/sergio-rodrigo%20royo/
    - Confirm that Author's page is correctly loaded
1. Check the following areas of our website for the link in **step 1**:
    1. **Latest Highlitghs** (this section is located in the landing page)
    1. Publications page (it's the first publication by the time this PR has been created)
1. Check in the bottom of https://codurance.com/2018/01/25/lambda-calculus-in-clojure-part-2/ for the link in **step 1**
    1. Author's name
    1. `ALL AUTHORS POST` button

1. Repeat steps **1** to **3**, using the deployed preview to confirm that all URLs to `/sergio-rodrigo%20royo/` have been replaced by `/sergio-rodrigo-royo/`

Fixes #885 