### PR TITLE
Added the spanish site to the workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
           paths:
             - _utility
             - _site
+            - _site_es
 
   production:
     <<: *common_info


### PR DESCRIPTION
The lack of the _site_es directory doesn't trigger an error on pre.