### PR TITLE
Correct docker-compose command to build all posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Run container in a watch and auto rebuild mode:
 
     docker-compose up
 
-Remove container:
+Stop container:
     
-    docker-compose down
+    docker-compose stop
 
 Destroy container:
 
@@ -45,11 +45,11 @@ Open site:
     
 Run this if you want all posts (slower rebuild):
 
-    docker-compose -f docker-compose.yml up
+    docker-compose run --service-ports site bundle exec rake serve
 
 If you want to start the container with a different command use:
 
-    docker-compose run site <command>
+    docker-compose run --service-ports site <command>
 
 Destroy the container and all volumes for this project.
 Run this if your container is broken.


### PR DESCRIPTION
Volumes were not mounted and ports were not exposed before.

About the `--service-ports` flag:

>The second difference is that the docker-compose run command does not create any of the ports specified in the service configuration. 
> This prevents port collisions with already-open ports. If you do want the service’s ports to be created and mapped to the host, specify the --service-ports flag
```
https://docs.docker.com/compose/reference/run/