### PR TITLE
Remove share this

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -103,8 +103,3 @@
 
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.8.0/highlight.min.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
-
-<!-- ShareThis -->
-<script type="text/javascript">var switchTo5x=true;</script>
-<script type="text/javascript" src="https://ws.sharethis.com/button/buttons.js"></script>
-<script type="text/javascript">stLight.options({publisher: "8b795ed1-9577-43d1-9e4e-55c54306336b", doNotHash: true, doNotCopy: false, hashAddressBar: false});</script>

--- a/_includes/publication.html
+++ b/_includes/publication.html
@@ -52,42 +52,9 @@
             {% endif %}
 
             <!-- Social Icons -->
-            <div class="text-center">
-                <h3 class="h6 g-color-black g-font-weight-600 text-uppercase mb-3">Share:</h3>
-                <ul class="list-inline g-mb-60">
-                    <li class="list-inline-item g-mx-2">
-                        <a class="u-icon-v1 u-icon-slide-up--hover g-color-gray-dark-v4 g-color-facebook--hover" href="http://www.facebook.com/sharer/sharer.php?u={{ site.url }}{{ site.baseurl }}{{ page.url }}&title={{ page.title }}">
-                            <i class="g-font-size-default g-line-height-1 u-icon__elem-regular fa fa-facebook"></i>
-                            <i class="g-font-size-default g-line-height-0_8 u-icon__elem-hover fa fa-facebook"></i>
-                        </a>
-                    </li>
-                    <li class="list-inline-item g-mx-2">
-                        <a class="u-icon-v1 u-icon-slide-up--hover g-color-gray-dark-v4 g-color-twitter--hover" href="https://twitter.com/intent/tweet?text={{ page.title }}&url={{ site.url }}{{ site.baseurl }}{{ page.url }}&hashtags={{ page.tags | join: ',' }}">
-                            <i class="g-font-size-default g-line-height-1 u-icon__elem-regular fa fa-twitter"></i>
-                            <i class="g-font-size-default g-line-height-0_8 u-icon__elem-hover fa fa-twitter"></i>
-                        </a>
-                    </li>
-                    <li class="list-inline-item g-mx-2">
-                        <a class="u-icon-v1 u-icon-slide-up--hover g-color-gray-dark-v4 g-color-google-plus--hover" href="https://plus.google.com/share?url={{ site.url }}{{ site.baseurl }}{{ page.url }}">
-                            <i class="g-font-size-default g-line-height-1 u-icon__elem-regular fa fa-google-plus"></i>
-                            <i class="g-font-size-default g-line-height-0_8 u-icon__elem-hover fa fa-google-plus"></i>
-                        </a>
-                    </li>
-                    <li class="list-inline-item g-mx-2">
-                        <a class="u-icon-v1 u-icon-slide-up--hover g-color-gray-dark-v4 g-color-linkedin--hover" href="http://www.linkedin.com/shareArticle?mini=true&title={{ page.title }}&summary={{ page.abstract }}&url={{ site.url }}{{ site.baseurl }}{{ page.url }}">
-                            <i class="g-font-size-default g-line-height-1 u-icon__elem-regular fa fa-linkedin"></i>
-                            <i class="g-font-size-default g-line-height-0_8 u-icon__elem-hover fa fa-linkedin"></i>
-                        </a>
-                    </li>
-                    <li class="list-inline-item g-mx-2">
-                        <a class="u-icon-v1 u-icon-slide-up--hover g-color-gray-dark-v4 g-color-reddit--hover" href="http://www.reddit.com/submit?url={{ site.url }}{{ site.baseurl }}{{ page.url }}&title={{ page.title }}">
-                            <i class="g-font-size-default g-line-height-1 u-icon__elem-regular fa fa-reddit"></i>
-                            <i class="g-font-size-default g-line-height-0_8 u-icon__elem-hover fa fa-reddit"></i>
-                        </a>
-                    </li>
-                </ul>
-            </div>
+            {% include social_icons.html %}
             <!-- End Social Icons -->
+
             {% for member in site.data.team %} {% if page.author == member.name and page.asset-type != "newsletter" %}
             <!-- Author -->
             <div class="g-brd-top g-brd-gray-light-v3 g-pt-60 g-pb-100">

--- a/_includes/social_icons.html
+++ b/_includes/social_icons.html
@@ -1,0 +1,35 @@
+<div class="text-center">
+    <h3 class="h6 g-color-black g-font-weight-600 text-uppercase mb-3">Share:</h3>
+    <ul class="list-inline g-mb-60">
+        <li class="list-inline-item g-mx-2">
+            <a class="u-icon-v1 u-icon-slide-up--hover g-color-gray-dark-v4 g-color-facebook--hover" href="http://www.facebook.com/sharer/sharer.php?u={{ site.url }}{{ site.baseurl }}{{ page.url }}&title={{ page.title }}">
+                <i class="g-font-size-default g-line-height-1 u-icon__elem-regular fa fa-facebook"></i>
+                <i class="g-font-size-default g-line-height-0_8 u-icon__elem-hover fa fa-facebook"></i>
+            </a>
+        </li>
+        <li class="list-inline-item g-mx-2">
+            <a class="u-icon-v1 u-icon-slide-up--hover g-color-gray-dark-v4 g-color-twitter--hover" href="https://twitter.com/intent/tweet?text={{ page.title }}&url={{ site.url }}{{ site.baseurl }}{{ page.url }}&hashtags={{ page.tags | join: ',' }}">
+                <i class="g-font-size-default g-line-height-1 u-icon__elem-regular fa fa-twitter"></i>
+                <i class="g-font-size-default g-line-height-0_8 u-icon__elem-hover fa fa-twitter"></i>
+            </a>
+        </li>
+        <li class="list-inline-item g-mx-2">
+            <a class="u-icon-v1 u-icon-slide-up--hover g-color-gray-dark-v4 g-color-google-plus--hover" href="https://plus.google.com/share?url={{ site.url }}{{ site.baseurl }}{{ page.url }}">
+                <i class="g-font-size-default g-line-height-1 u-icon__elem-regular fa fa-google-plus"></i>
+                <i class="g-font-size-default g-line-height-0_8 u-icon__elem-hover fa fa-google-plus"></i>
+            </a>
+        </li>
+        <li class="list-inline-item g-mx-2">
+            <a class="u-icon-v1 u-icon-slide-up--hover g-color-gray-dark-v4 g-color-linkedin--hover" href="http://www.linkedin.com/shareArticle?mini=true&title={{ page.title }}&summary={{ page.abstract }}&url={{ site.url }}{{ site.baseurl }}{{ page.url }}">
+                <i class="g-font-size-default g-line-height-1 u-icon__elem-regular fa fa-linkedin"></i>
+                <i class="g-font-size-default g-line-height-0_8 u-icon__elem-hover fa fa-linkedin"></i>
+            </a>
+        </li>
+        <li class="list-inline-item g-mx-2">
+            <a class="u-icon-v1 u-icon-slide-up--hover g-color-gray-dark-v4 g-color-reddit--hover" href="http://www.reddit.com/submit?url={{ site.url }}{{ site.baseurl }}{{ page.url }}&title={{ page.title }}">
+                <i class="g-font-size-default g-line-height-1 u-icon__elem-regular fa fa-reddit"></i>
+                <i class="g-font-size-default g-line-height-0_8 u-icon__elem-hover fa fa-reddit"></i>
+            </a>
+        </li>
+    </ul>
+</div>

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -8,49 +8,42 @@ group:
   <div class="blog-author bg-color-white margin-bottom-30">
       <div class="row">
           <div class="col-sm-3 pull-left">
-		{% if page.image.src %}
-			{% assign eventImage = page.image.src %}
-		{% else %}
-			{% assign eventImage = site.default_post_image %}
-		{% endif %}
-		<img class="img-fluid" id="author-img" src="{{ eventImage }}" alt="{{ page.title }}">
-		{% if page.speaker %}
-			<h3>{{ page.speaker | author_links }}</h3>
-		{% endif %}
-          </div>
-          <div class="col-sm-9">
-            <div class="blog-author-desc">
-              <div class="overflow-h">
-                  	<h1>{{ page.title }}</h1>
-			<ul style="list-style:none;float:none;">							
-				{% if page.event-dates %}
-				<li> {{ page.event-dates.starts | date_to_string }}
-				{% if page.event-dates.ends %}
-						- {{ page.event-dates.ends | date_to_string }}              
-					{% endif %}
-				</li>
-				{% if page.speaker %}
-				<li>{% t event.author_title %} {{ page.speaker | author_links }}</li>
-				{% endif %}
-				<li>{% t event.location_title %} </li><li> {{ page.location }}</li>
-				{% endif %}
-				<li><a href="{{ page.event-page-url }}"><i class="fa fa-tags"></i><span class="blog-tag-margin"> {% t event.link_title %} </span></a></li>
-			</ul>
+							{% if page.image.src %}
+								{% assign eventImage = page.image.src %}
+							{% else %}
+								{% assign eventImage = site.default_post_image %}
+							{% endif %}
+							<img class="img-fluid" id="author-img" src="{{ eventImage }}" alt="{{ page.title }}">
+							{% if page.speaker %}
+								<h3>{{ page.speaker | author_links }}</h3>
+							{% endif %}
+					</div>
+					<div class="col-sm-9">
+						<div class="blog-author-desc">
+							<div class="overflow-h">
+										<h1>{{ page.title }}</h1>
+								<ul style="list-style:none;float:none;">							
+									{% if page.event-dates %}
+									<li> {{ page.event-dates.starts | date_to_string }}
+									{% if page.event-dates.ends %}
+											- {{ page.event-dates.ends | date_to_string }}              
+										{% endif %}
+									</li>
+									{% if page.speaker %}
+									<li>{% t event.author_title %} {{ page.speaker | author_links }}</li>
+									{% endif %}
+									<li>{% t event.location_title %} </li><li> {{ page.location }}</li>
+									{% endif %}
+									<li><a href="{{ page.event-page-url }}"><i class="fa fa-tags"></i><span class="blog-tag-margin"> {% t event.link_title %} </span></a></li>
+								</ul>
               </div>
             </div> 
           </div>
         </div>
-	<div class="row col-sm-9">
-	<p>{{ content }}</p>
-	</div>
-	<div class="row">
-		<div id="sharethisButtons">
-			<span class='pull-right st_twitter_large' displayText='Tweet' st_url='{{ site.url }}{{ page.url }}'></span>
-			<span class='pull-right st_linkedin_large' displayText='LinkedIn' st_url='{{ site.url }}{{ page.url }}'></span>
-			<span class='pull-right st_email_large' displayText='Email' st_url='{{ site.url }}{{ page.url }}'></span>
-			<span class='pull-right st_sharethis_large' displayText='ShareThis' st_url='{{ site.url }}{{ page.url }}'></span>
-		</div>
-	</div>
+			<div class="row col-sm-9">
+				<p>{{ content }}</p>
+				{% include social_icons.html %}
+			</div>
 
   </div>
 </div>     

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -6,45 +6,43 @@ group:
 ---
 <div class="container content-sm">
   <div class="blog-author bg-color-white margin-bottom-30">
-      <div class="row">
-          <div class="col-sm-3 pull-left">
-							{% if page.image.src %}
-								{% assign eventImage = page.image.src %}
-							{% else %}
-								{% assign eventImage = site.default_post_image %}
-							{% endif %}
-							<img class="img-fluid" id="author-img" src="{{ eventImage }}" alt="{{ page.title }}">
-							{% if page.speaker %}
-								<h3>{{ page.speaker | author_links }}</h3>
-							{% endif %}
-					</div>
-					<div class="col-sm-9">
-						<div class="blog-author-desc">
-							<div class="overflow-h">
-										<h1>{{ page.title }}</h1>
-								<ul style="list-style:none;float:none;">							
-									{% if page.event-dates %}
-									<li> {{ page.event-dates.starts | date_to_string }}
+		<div class="row">
+				<div class="col-sm-3 pull-left">
+						{% if page.image.src %}
+							{% assign eventImage = page.image.src %}
+						{% else %}
+							{% assign eventImage = site.default_post_image %}
+						{% endif %}
+						<img class="img-fluid" id="author-img" src="{{ eventImage }}" alt="{{ page.title }}">
+						{% if page.speaker %}
+							<h3>{{ page.speaker | author_links }}</h3>
+						{% endif %}
+				</div>
+				<div class="col-sm-9">
+					<div class="blog-author-desc">
+						<div class="overflow-h">
+									<h1>{{ page.title }}</h1>
+							<ul style="list-style:none;float:none;">							
+								{% if page.event-dates %}
+								<li> {{ page.event-dates.starts | date_to_string }}
 									{% if page.event-dates.ends %}
 											- {{ page.event-dates.ends | date_to_string }}              
-										{% endif %}
-									</li>
+									{% endif %}
+								</li>
 									{% if page.speaker %}
 									<li>{% t event.author_title %} {{ page.speaker | author_links }}</li>
 									{% endif %}
 									<li>{% t event.location_title %} </li><li> {{ page.location }}</li>
-									{% endif %}
-									<li><a href="{{ page.event-page-url }}"><i class="fa fa-tags"></i><span class="blog-tag-margin"> {% t event.link_title %} </span></a></li>
-								</ul>
-              </div>
-            </div> 
-          </div>
-        </div>
+								{% endif %}
+								<li><a href="{{ page.event-page-url }}"><i class="fa fa-tags"></i><span class="blog-tag-margin"> {% t event.link_title %} </span></a></li>
+							</ul>
+						</div>
+					</div> 
+				</div>
+			</div>
 			<div class="row col-sm-9">
 				<p>{{ content }}</p>
 				{% include social_icons.html %}
 			</div>
-
   </div>
-</div>     
-      <!--End Event Info-->
+</div>


### PR DESCRIPTION
Resolves #1063

Turns out it was only used for the events publications.
I removed sharethis plugin and used the same buttons of the other publications.

You can test it on page /events/2017-03-21-sockates-uk/

Before
![image](https://user-images.githubusercontent.com/6770932/45945680-322d1a00-bfe6-11e8-80e3-f625039d716f.png)

Now
![image](https://user-images.githubusercontent.com/6770932/45945702-43762680-bfe6-11e8-88b2-2026db91e0bd.png)
