### PR TITLE
Added a guard clause to the linkify anchors code.

### DIFF
--- a/src/assets/custom/js/custom.js
+++ b/src/assets/custom/js/custom.js
@@ -188,6 +188,11 @@ $(window).resize(function () {
 })();
   
 var linkifyAnchors = function (level, containingElement) {
+    
+    if (!containingElement) {
+        return
+    }
+    
     var headers = containingElement.getElementsByTagName("h" + level);
     for (var h = 0; h < headers.length; h++) {
       var header = headers[h];


### PR DESCRIPTION
This fixes one of the breaks on the custom.js.