### PR TITLE
Added documentation that allows backstop to be used without 

### DIFF
--- a/tools/snapshots/README.md
+++ b/tools/snapshots/README.md
@@ -33,18 +33,14 @@ Care needs to be taken when choosing pages to compare. Dynamically generated lis
 
 ## Using backstop for a docker container instead of local installation
 
-backstopjs provides a docker container that allows you 
+backstopjs provides a docker container that allows you to run without installing it. 
 
 Found here: https://blog.docksal.io/visual-regression-testing-with-backstopjs-in-a-docker-container-dfd1b9ae8582
 
-```
-docker run --rm -v $(pwd):/src backstopjs/backstopjs --version
-```
-
-You can add a shell alias (in .bashrc, .zshrc, etc.) for convenience:
+I have created three bash scripts to abstract the running of backstopjs without deploying it:
 
 ```
-alias backstop='docker run --rm -v $(pwd):/src docksal/backstopjs "$@"'
+docker-backstop-setup.sh
+docker-backstop-reference.sh
+docker-backtop-test.sh
 ```
-
-This will work exactly like a natively installed backstop.

--- a/tools/snapshots/README.md
+++ b/tools/snapshots/README.md
@@ -30,3 +30,21 @@ It is also possible to add viewports within scenarios to exercise specific condi
 all of the tests.
 
 Care needs to be taken when choosing pages to compare. Dynamically generated lists will frequently differ between reference and actual. We have also set a 0.15% global difference threshold to allow some variation. This may need to be reduced for specific tests.
+
+## Using backstop for a docker container instead of local installation
+
+backstopjs provides a docker container that allows you 
+
+Found here: https://blog.docksal.io/visual-regression-testing-with-backstopjs-in-a-docker-container-dfd1b9ae8582
+
+```
+docker run --rm -v $(pwd):/src backstopjs/backstopjs --version
+```
+
+You can add a shell alias (in .bashrc, .zshrc, etc.) for convenience:
+
+```
+alias backstop='docker run --rm -v $(pwd):/src docksal/backstopjs "$@"'
+```
+
+This will work exactly like a natively installed backstop.

--- a/tools/snapshots/docker-backstop-reference.sh
+++ b/tools/snapshots/docker-backstop-reference.sh
@@ -1,0 +1,1 @@
+docker run --rm -v $(pwd):/src backstopjs/backstopjs reference

--- a/tools/snapshots/docker-backstop-setup.sh
+++ b/tools/snapshots/docker-backstop-setup.sh
@@ -1,0 +1,1 @@
+docker run --rm -v $(pwd):/src backstopjs/backstopjs --version

--- a/tools/snapshots/docker-backstop-test.sh
+++ b/tools/snapshots/docker-backstop-test.sh
@@ -1,0 +1,2 @@
+docker run --network host --rm -v $(pwd):/src backstopjs/backstopjs test
+open backstop_data/html_report/index.html 


### PR DESCRIPTION
installing it locally.

This resolves #1131 since the supplied backstopjs/backstopjs docker image already does this.