### PR TITLE
Expand tests to image helper

### DIFF
--- a/spec/_plugins/author_generator_spec.rb
+++ b/spec/_plugins/author_generator_spec.rb
@@ -1,6 +1,6 @@
 require 'jekyll'
 require 'jekyll/tagging'
-require_relative '../src/_plugins/author_generator.rb'
+require_relative '../../src/_plugins/author_generator.rb'
 require 'date' 
 
 
@@ -21,20 +21,16 @@ class DummyConfig
   end  
 
   def config
-    self
+    { 
+      'author_dir' => 'author_dir', 
+      'baseurl' => 'baseurl' 
+    }
   end  
 
-  def [](a)
-    if a == nil
-      return ''
-    end
-    a
-  end  
 end
 
 
 describe 'AuthorGenerator' do
-
 
   let(:subject) { TestFilters.new }
 
@@ -82,6 +78,18 @@ describe 'AuthorGenerator' do
       expect(subject.author_links(['Harry Potter', '', 'Ron Weasley'])).to eq("<a class='author' href='baseurl/author_dir/harry-potter/'>Harry Potter</a>, <a class='author' href='baseurl/author_dir/ron-weasley/'>Ron Weasley</a>")
     end
 
-  end  
+  end
+  
+  describe "Generate Authors" do
+    
+    it 'Generate calls write_author_indexes' do
+      site = double  
+      expect(site).to receive :write_author_indexes
+      
+      genAuthor = Jekyll::GenerateAuthor.new
+      genAuthor.generate(site)
+    end
 
+  end
+  
 end

--- a/spec/_plugins/author_generator_spec.rb
+++ b/spec/_plugins/author_generator_spec.rb
@@ -8,12 +8,12 @@ class TestFilters
   include Jekyll::Filters
 
   def initialize()
-    @context = DummyConfig.new
+    @context = DummyAuthorGeneratorConfig.new
   end
 
 end 
 
-class DummyConfig
+class DummyAuthorGeneratorConfig
   attr_reader :config
 
   def registers

--- a/spec/_plugins/image_helper_spec.rb
+++ b/spec/_plugins/image_helper_spec.rb
@@ -2,6 +2,27 @@ require 'jekyll'
 require 'jekyll/tagging'
 require_relative '../../src/_plugins/image_helper.rb'
 
+class DummyImageConfig
+  attr_reader :config
+
+  def registers
+    {:site => self}
+  end  
+
+  def config
+    { 
+      'baseurl' => 'baseurl',
+    }
+  end  
+end
+
+module Jekyll
+    class ImageTag < Liquid::Tag
+       attr_accessor :context    
+    end    
+end    
+  
+
 describe 'ImageTag' do
 
     it 'Can render a simple image with alt text' do
@@ -10,14 +31,27 @@ describe 'ImageTag' do
 
       tag = Jekyll::ImageTag.send :new, 'img', '/assets/custom/img/blog/ncraft-2017/event-storming-with-brandolini.jpg "ALT"', token
 
-      expect(tag.render(nil)).to eq('<p></p><img src="/assets/custom/img/blog/ncraft-2017/event-storming-with-brandolini.jpg"  alt="ALT" title="ALT" class="img img-center img-fluid style-screengrab">')
+      tag.context = DummyImageConfig.new  
+
+      expect(tag.render(nil)).to eq('<p></p><img src="baseurl/assets/custom/img/blog/ncraft-2017/event-storming-with-brandolini.jpg"  alt="ALT" title="ALT" class="img img-center img-fluid style-screengrab">')
     end
-    
-    it 'will throw an exception when an img does not have a non-blank alt tag' do
+
+    it 'Leaves non-relative images alone' do
         token = double
         expect(token).to receive :line_number
   
-        tag = Jekyll::ImageTag.send :new, 'img', '/a-real-image.jpg ""', token
+        tag = Jekyll::ImageTag.send :new, 'img', 'http://www.randomkittengenerator.com/cats/rotator.php "ALT"', token
+  
+        expect(tag.render(nil)).to eq('<p></p><img src="http://www.randomkittengenerator.com/cats/rotator.php"  alt="ALT" title="ALT" class="img img-center img-fluid style-screengrab">')
+        
+    end    
+    
+    it 'will throw an exception when an img has an empty alt tag' do
+        token = double
+        expect(token).to receive :line_number
+  
+        tag = Jekyll::ImageTag.send :new, 'img', 'baseurl/a-real-image.jpg ""', token
+        tag.context = DummyImageConfig.new  
     
         expect{tag.render(nil)}.to raise_error "Missing alt text: please describe the image for a blind user"
     end
@@ -26,7 +60,8 @@ describe 'ImageTag' do
         token = double
         expect(token).to receive :line_number
   
-        tag = Jekyll::ImageTag.send :new, 'img', '/a-real-image.jpg', token
+        tag = Jekyll::ImageTag.send :new, 'img', 'baseurl/a-real-image.jpg', token
+        tag.context = DummyImageConfig.new  
     
         expect{tag.render(nil)}.to raise_error "Missing alt text: please describe the image for a blind user"
     end

--- a/spec/_plugins/image_helper_spec.rb
+++ b/spec/_plugins/image_helper_spec.rb
@@ -1,0 +1,34 @@
+require 'jekyll'
+require 'jekyll/tagging'
+require_relative '../../src/_plugins/image_helper.rb'
+
+describe 'ImageTag' do
+
+    it 'Can render a simple image with alt text' do
+      token = double
+      expect(token).to receive :line_number
+
+      tag = Jekyll::ImageTag.send :new, 'img', '/assets/custom/img/blog/ncraft-2017/event-storming-with-brandolini.jpg "ALT"', token
+
+      expect(tag.render(nil)).to eq('<p></p><img src="/assets/custom/img/blog/ncraft-2017/event-storming-with-brandolini.jpg"  alt="ALT" title="ALT" class="img img-center img-fluid style-screengrab">')
+    end
+    
+    it 'will throw an exception when an img does not have a non-blank alt tag' do
+        token = double
+        expect(token).to receive :line_number
+  
+        tag = Jekyll::ImageTag.send :new, 'img', '/a-real-image.jpg ""', token
+    
+        expect{tag.render(nil)}.to raise_error "Missing alt text: please describe the image for a blind user"
+    end
+
+    it 'will throw an exception when an img is missing an alt tag' do
+        token = double
+        expect(token).to receive :line_number
+  
+        tag = Jekyll::ImageTag.send :new, 'img', '/a-real-image.jpg', token
+    
+        expect{tag.render(nil)}.to raise_error "Missing alt text: please describe the image for a blind user"
+    end
+
+end    

--- a/spec/_plugins/image_helper_spec.rb
+++ b/spec/_plugins/image_helper_spec.rb
@@ -2,7 +2,7 @@ require 'jekyll'
 require 'jekyll/tagging'
 require_relative '../../src/_plugins/image_helper.rb'
 
-class DummyImageConfig
+class DummyImageContext
   attr_reader :config
 
   def registers
@@ -31,9 +31,9 @@ describe 'ImageTag' do
 
       tag = Jekyll::ImageTag.send :new, 'img', '/assets/custom/img/blog/ncraft-2017/event-storming-with-brandolini.jpg "ALT"', token
 
-      tag.context = DummyImageConfig.new  
+      context = DummyImageContext.new  
 
-      expect(tag.render(nil)).to eq('<p></p><img src="baseurl/assets/custom/img/blog/ncraft-2017/event-storming-with-brandolini.jpg"  alt="ALT" title="ALT" class="img img-center img-fluid style-screengrab">')
+      expect(tag.render(context)).to eq('<p></p><img src="baseurl/assets/custom/img/blog/ncraft-2017/event-storming-with-brandolini.jpg"  alt="ALT" title="ALT" class="img img-center img-fluid style-screengrab">')
     end
 
     it 'Leaves non-relative images alone' do
@@ -51,9 +51,9 @@ describe 'ImageTag' do
         expect(token).to receive :line_number
   
         tag = Jekyll::ImageTag.send :new, 'img', 'baseurl/a-real-image.jpg ""', token
-        tag.context = DummyImageConfig.new  
+        context = DummyImageContext.new  
     
-        expect{tag.render(nil)}.to raise_error "Missing alt text: please describe the image for a blind user"
+        expect{tag.render(context)}.to raise_error "Missing alt text: please describe the image for a blind user"
     end
 
     it 'will throw an exception when an img is missing an alt tag' do
@@ -61,9 +61,9 @@ describe 'ImageTag' do
         expect(token).to receive :line_number
   
         tag = Jekyll::ImageTag.send :new, 'img', 'baseurl/a-real-image.jpg', token
-        tag.context = DummyImageConfig.new  
+        context = DummyImageContext.new  
     
-        expect{tag.render(nil)}.to raise_error "Missing alt text: please describe the image for a blind user"
+        expect{tag.render(context)}.to raise_error "Missing alt text: please describe the image for a blind user"
     end
 
 end    

--- a/src/_plugins/image_helper.rb
+++ b/src/_plugins/image_helper.rb
@@ -8,6 +8,7 @@ require 'open-uri'
 module Jekyll
 
   class ImageTag < Liquid::Tag
+
     @img = nil
     @alt = ""
 
@@ -28,7 +29,7 @@ module Jekyll
         end  
 
         if @img[0] == ("/")
-          @img = @context.registers[:site].config['baseurl'] + @img
+          @img = "#{context.registers[:site].config['baseurl']}#{@img}"
         end  
 
         "<p></p><img src=\"#{@img}\"  alt=\"#{@alt}\" title=\"#{@alt}\" class=\"img img-center img-fluid style-screengrab\">"

--- a/src/_plugins/image_helper.rb
+++ b/src/_plugins/image_helper.rb
@@ -26,7 +26,11 @@ module Jekyll
         if (@alt || "") == "" 
           raise "Missing alt text: please describe the image for a blind user"
         end  
-        
+
+        if @img[0] == ("/")
+          @img = @context.registers[:site].config['baseurl'] + @img
+        end  
+
         "<p></p><img src=\"#{@img}\"  alt=\"#{@alt}\" title=\"#{@alt}\" class=\"img img-center img-fluid style-screengrab\">"
       end
       

--- a/src/_plugins/image_helper.rb
+++ b/src/_plugins/image_helper.rb
@@ -23,6 +23,10 @@ module Jekyll
 
     def render(context)
       if @img
+        if (@alt || "") == "" 
+          raise "Missing alt text: please describe the image for a blind user"
+        end  
+        
         "<p></p><img src=\"#{@img}\"  alt=\"#{@alt}\" title=\"#{@alt}\" class=\"img img-center img-fluid style-screengrab\">"
       end
       

--- a/src/_posts/2017-05-19-my-first-year-at-codurance.md
+++ b/src/_posts/2017-05-19-my-first-year-at-codurance.md
@@ -58,7 +58,7 @@ There was a lot of work to do in my case.
 My mentor and I agreed on a strategy for learning; with test driven development as the main goal.
 We did set up a work plan for each week, and reviewed my progress weekly. The usual workload was roughly as: TDD katas in C# every week, in javascript every other week; reading a number of chapters of various books every week, studying a cloud design pattern and when possible implementing it; one blog post every two weeks (I did not always made this one); do a lightning talk every fortnight at the Codurance catch ups. 
 
-{% img /assets/custom/img/blog/my-first-year-at-codurance/a_typical_work_week.png "" %}
+{% img /assets/custom/img/blog/my-first-year-at-codurance/a_typical_work_week.png "Trello Board showing an apprenticeship week" %}
 
 Each week, after his day of work at the client, Alex would come to the Codurance office and spend an evening of about 3 hours or more and sit with me, reviewing my learnings asking questions, answering mines, and pair programming with me.
 <br/>

--- a/src/_posts/2017-06-04-ncraft-in-20-pictures.md
+++ b/src/_posts/2017-06-04-ncraft-in-20-pictures.md
@@ -28,7 +28,7 @@ Good food always makes for a good conference (you guessed I'm french here).
 Developers are fun and keyboards are a good way to socialise.
 
 
-{% img /assets/custom/img/blog/ncraft-2017/bigdata-at-criteo.jpg "Fundamental Lessions: Know your dependencies, eliminate your dependency on the internet, use a cache" %}
+{% img /assets/custom/img/blog/ncraft-2017/bigdata-at-criteo.jpg "Fundamental Lessons: Know your dependencies, eliminate your dependency on the internet, use a cache" %}
 Big data can be so big [you DDOS yourself](http://ncrafts.io/speaker/SavarinAnna).
 
 

--- a/src/_posts/2017-06-04-ncraft-in-20-pictures.md
+++ b/src/_posts/2017-06-04-ncraft-in-20-pictures.md
@@ -17,18 +17,18 @@ It was full of fun, socialising and learning.
 
 Here are some of my takeways of those three days of awesomeness:
 
-{% img /assets/custom/img/blog/ncraft-2017/event-storming-with-brandolini.jpg "" %}
+{% img /assets/custom/img/blog/ncraft-2017/event-storming-with-brandolini.jpg "Alberto Brandolini adding a post-it to a wall covered in post-its" %}
 "If you have an event driven architecture, the gap between post-its (resulting from the event storming session) and the code should be small". [Alberto Brandolini](http://twitter.com/ziobrando).
 
-{% img /assets/custom/img/blog/ncraft-2017/ncraft-buffet.jpg "" %}
+{% img /assets/custom/img/blog/ncraft-2017/ncraft-buffet.jpg "Food buffet at NCrafts" %}
 Good food always makes for a good conference (you guessed I'm french here).
 
 
-{% img /assets/custom/img/blog/ncraft-2017/customised-keyboard.jpg "" %}
+{% img /assets/custom/img/blog/ncraft-2017/customised-keyboard.jpg "A custom built keyboard - including android, apple and DON'T PANIC keys" %}
 Developers are fun and keyboards are a good way to socialise.
 
 
-{% img /assets/custom/img/blog/ncraft-2017/bigdata-at-criteo.jpg "" %}
+{% img /assets/custom/img/blog/ncraft-2017/bigdata-at-criteo.jpg "Fundamental Lessions: Know your dependencies, eliminate your dependency on the internet, use a cache" %}
 Big data can be so big [you DDOS yourself](http://ncrafts.io/speaker/SavarinAnna).
 
 

--- a/src/_posts/2017-06-04-ncraft-in-20-pictures.md
+++ b/src/_posts/2017-06-04-ncraft-in-20-pictures.md
@@ -32,43 +32,43 @@ Developers are fun and keyboards are a good way to socialise.
 Big data can be so big [you DDOS yourself](http://ncrafts.io/speaker/SavarinAnna).
 
 
-{% img /assets/custom/img/blog/ncraft-2017/mob-testing-live-demo.png "" %}
+{% img /assets/custom/img/blog/ncraft-2017/mob-testing-live-demo.png "Slides about mobbing" %}
 [Mobbing is not just for devs](http://ncrafts.io/speaker/maaretp).
 
 
-{% img /assets/custom/img/blog/ncraft-2017/webber-on-communities-of-practice.jpg "" %}
+{% img /assets/custom/img/blog/ncraft-2017/webber-on-communities-of-practice.jpg "Building Communities of practice (tacit.pub/tacitbooks)" %}
 [Community of practices](http://ncrafts.io/speaker/ewebber) are efficient ways to break team silo.
 
 
-{% img /assets/custom/img/blog/ncraft-2017/xp-at-unruly.jpg "" %}
+{% img /assets/custom/img/blog/ncraft-2017/xp-at-unruly.jpg "Word Cloud of Extreme Practices" %}
 [XP to the extreme](http://ncrafts.io/speaker/rachelcdavies) works.
 
 
-{% img /assets/custom/img/blog/ncraft-2017/ncrafted-beer.jpg "" %}
+{% img /assets/custom/img/blog/ncraft-2017/ncrafted-beer.jpg "A bottle of Newcrafts Black IPA" %}
 Craft beer is a must have, looking forward to the veggie smoothie trend.
 
 
-{% img /assets/custom/img/blog/ncraft-2017/sabine-safi-about-going-teal-2.jpg "" %}
+{% img /assets/custom/img/blog/ncraft-2017/sabine-safi-about-going-teal-2.jpg "Slide about Reinventing Organizations: The Epiphany" %}
 [Becoming TEAL overnight](http://ncrafts.io/speaker/SabineSafi) might not be a good idea, I feel lucky to be part of a TEAL aspiring company.
 
 
-{% img /assets/custom/img/blog/ncraft-2017/sabine-safi-about-going-teal.jpg "" %}
+{% img /assets/custom/img/blog/ncraft-2017/sabine-safi-about-going-teal.jpg "Slide stating 'Biggest Mistakes'" %}
 The best talks are the one full of courage to face one's vulnerabilities.
 
 
-{% img /assets/custom/img/blog/ncraft-2017/168-hour-week.png "" %}
+{% img /assets/custom/img/blog/ncraft-2017/168-hour-week.png "Antoine Vernois with photos of chickens and a building." %}
 [Coding among the chickens](http://ncrafts.io/speaker/avernois) sounds like something I would enjoy doing.
 
 
-{% img /assets/custom/img/blog/ncraft-2017/ncraft-open-space.jpg "" %}
+{% img /assets/custom/img/blog/ncraft-2017/ncraft-open-space.jpg "An open space discussion in progress" %}
 Open spaces at conferences are cool, especially when being reminded that the talks will be recorded (FOMO contained).
 
 
-{% img /assets/custom/img/blog/ncraft-2017/the-dev-awakening.jpg "" %}
+{% img /assets/custom/img/blog/ncraft-2017/the-dev-awakening.jpg "Ly-Jia Goldstein with 'The legend of Devs Awakening' " %}
 We as developers have duty to [not harm and inform](http://ncrafts.io/speaker/Ly_Jia) non tech savvy.
 
 
-{% img /assets/custom/img/blog/ncraft-2017/craftsmanship-father-to-son.jpg "" %}
+{% img /assets/custom/img/blog/ncraft-2017/craftsmanship-father-to-son.jpg "Gilles Roustan with his grandfathers quote: 'A bad worker always complains about his tools.'" %}
 I completely buy into the metaphore of software development as an artisanal trade and [the comparison with masonry](http://ncrafts.io/speaker/GillesRoustan).
 
 <iframe style="height: 400px; width: 100%;" src="https://www.youtube.com/embed/nytXq9Ql37g"></iframe>
@@ -76,7 +76,7 @@ I completely buy into the metaphore of software development as an artisanal trad
 But diversity in attendees is lacking and a sad reflection of our industry.
 
 
-{% img /assets/custom/img/blog/ncraft-2017/ncraft-closing-keynote.jpg "" %}
+{% img /assets/custom/img/blog/ncraft-2017/ncraft-closing-keynote.jpg "Alberto Brandolini with his quote: 'Software Development is a learning process. Working code is a side effect.'" %}
 Software development is a [life of learning](http://ncrafts.io/speaker/ziobrando) and that's why we chose to code.
 
 You can watch [this space](http://videos.ncrafts.io/) for videos of the 2017's edition.


### PR DESCRIPTION
We now have unit tests for the image helper.

These changes included adding a validation rule that will fail the build if the alt text is empty or missing.