### PR TITLE
Filter down the sitemap to only record each author once. 

### DIFF
--- a/build/config/_config.yml
+++ b/build/config/_config.yml
@@ -46,6 +46,13 @@ pagination:
   paginate_path: "/page:num"
   sort_reverse: true 
 
+# Exclude the assets from the sitemap
+defaults:
+  - scope:
+      path: assets/*
+    values:
+      sitemap: false 
+
 plugins:
   - jekyll-sitemap
   - jekyll-redirect-from

--- a/src/_plugins/author_generator.rb
+++ b/src/_plugins/author_generator.rb
@@ -68,6 +68,7 @@ module Jekyll
 
     # Loops through the list of author pages and processes each one.
     def write_author_indexes
+      seen_author = []
       if self.layouts.key? 'author_index'
         dir = self.config['author_dir'] || 'authors'
         (self.posts.docs + self.collections['videos'].docs).each do |post|
@@ -77,7 +78,11 @@ module Jekyll
           end
           post_authors.each do |author|
             author_dir = AuthorNameToPath.parse(author)
-            self.write_author_index(File.join(dir, author_dir), author)
+            #Only do this once per author, otherwise overwriting files and duplicating index
+            if !seen_author.include?(author)
+              self.write_author_index(File.join(dir, author_dir), author)
+              seen_author << author
+            end
           end
         end
       # Throw an exception if the layout couldn't be found.


### PR DESCRIPTION
Also exclude the assets.

I have not yet worked out how to test the Site object.
However I can test the site output using a powershell script.

Here is the powershell script

[xml]$data = (iwr "http://localhost:4000/sitemap.xml" | select -expand content); $data.urlset.url | measure | select count

This change reduces the site from 179 to 118 entries on the local 5 article build.
The live site has 1071 entries.