### PR TITLE
Updated privacy policy to account for events.

### DIFF
--- a/src/policies/privacy.html
+++ b/src/policies/privacy.html
@@ -10,13 +10,13 @@ title: Privacy Policy
         </div>
         <div class="margin-bottom-30">
             <p>Please take a moment to read our Privacy Policy so you know what choices you have about the information we may ask you for. This policy may change from time to time so it's a good idea to come back and read through it again.</p>
-            <p>In order to provide you with the full range of Codurance's services, we are sometimes required to collect information about you.</p>
+            <p>In order to provide you with the full range of Codurance's services and events, we are sometimes required to collect information about you.</p>
         </div>
         <div class="margin-bottom-30">
             <h4>Introduction</h4>
             <p>Codurance is a data controller for the purposes of the UK Data Protection Act (DPA) 2018 and the EU General Data Protection Regulation (GDPR) and is registered as such with the Information Commissioner’s Office (ICO).</p>
             <p>Codurance is committed to protecting the privacy of our clients. This privacy notice is intended to set out the basis upon which any personal data or information we collect from you, or that you provide to us, may be collected and processed by (or on behalf of) Codurance.</p>
-            <p>It applies to use of our website, our professional services or during any communications with you.</p>
+            <p>It applies to use of our website, our professional services, our events or during any communications with you.</p>
         </div>
         <div class="margin-bottom-30">
             <h4>Data protection</h4>
@@ -46,17 +46,18 @@ title: Privacy Policy
                 <li>To communicate with you regarding your query or application. We may contact you by post, email, telephone or text message. You may opt out/unsubscribe from such communications at any time by emailing privacy@codurance.com;</li>
                 <li>To process any job application you may make to us (including any sensitive personal information you provide);</li>
                 <li>To provide or administer services;</li>
+                <li>To communicate, provide and administer events;</li>
                 <li>To update client records;</li>
                 <li>To confirm identity, ascertain credit worthiness and trace whereabouts where necessary;</li>
                 <li>To comply with legal and regulatory requirements including verifying the identity of new clients/associates (and in certain circumstances existing clients/associates) to comply with anti-money laundering regulations, ‘right to work’ and other legislative requirements applicable to Codurance;</li>
                 <li>To comply with law enforcement.</li>
             </ul>
             <p>As described in this policy, personal information will be retained by us and will not be sold, transferred or otherwise disclosed to any third party, other than for the purpose of lawful processing. Personal information may be anonymised / pseudonymised for the purpose of research to inform our marketing and development strategies or where such disclosure is required by law or court order.</p>
-            <p>If your personal information changes or you no longer wish to receive a particular communication from us please let us know and we will correct, update or remove your details. This can be done by emailing hello@codurance.com</p>
+            <p>If your personal information changes or you no longer wish to receive a particular communication from us please let us know and we will correct, update or remove your details. This can be done by emailing privacy@codurance.com</p>
         </div>
         <div class="margin-bottom-30">
             <h4>Your agreement</h4>
-            <p>By entering your details in the fields requested, you enable Codurance and its service providers to provide you with the services you select.</p>
+            <p>By entering your details in the fields requested, you enable Codurance and its service providers to provide you with the services you selected and/or events you have registered for.</p>
         </div>
         <div class="margin-bottom-30">
             <h4>Codurance uses cookies and collects IP addresses</h4>
@@ -72,7 +73,7 @@ title: Privacy Policy
                 <li>to personalise the way Codurance content is presented to you. IP addresses are used to identify the location of users, the number of visits from different countries and also to block disruptive use and to analyse and improve the services offered on Codurance websites e.g. to provide you with the most user-friendly navigation experience;</li>
                 <li>to enable us to review, develop and improve the products, services and special offers online;</li>
                 <li>to occasionally carry out market research</li>
-                <li>to send you details of Codurance promotions, products, services, special offers and rewards that we think will be of interest to you. It's up to you to decide whether or not you want to receive this information.</li>
+                <li>to send you details of Codurance promotions, products, services, events, special offers and rewards that we think will be of interest to you. It's up to you to decide whether or not you want to receive this information.</li>
             </ul>
             <p>Where Codurance proposes using your personal information for any other uses we will ensure that we notify you first. You will also be given the opportunity to withhold or withdraw your consent for your use other than as listed above.</p>
         </div>
@@ -80,7 +81,7 @@ title: Privacy Policy
             <h4>When will Codurance contact me?</h4>
             <p>Codurance may contact you:</p>
             <ul>
-                <li>in relation to the functioning of any service you have signed up for in order to ensure that Codurance can deliver the services to you;</li>
+                <li>in relation to the functioning of any service or event you have signed up or registered for in order to ensure that Codurance can deliver the services to you;</li>
                 <li>where you have opted to receive further correspondence;</li>
                 <li>in relation to any contribution you have made to Codurance, e.g. surveys (participation is always voluntary)</li>
                 <li>and for marketing purposes where you have specifically agreed to this</li>
@@ -124,7 +125,7 @@ title: Privacy Policy
                 <br/> 15 Northburgh Street, 5th Floor
                 <br/> London, UK
                 <br/> EC1V 0JR
-                <br/> Email: hello@codurance.com
+                <br/> Email: privacy@codurance.com
             </p>
         </div>
     </div>

--- a/src/policies/privacy.html
+++ b/src/policies/privacy.html
@@ -51,6 +51,11 @@ title: Privacy Policy
                 <li>To confirm identity, ascertain credit worthiness and trace whereabouts where necessary;</li>
                 <li>To comply with legal and regulatory requirements including verifying the identity of new clients/associates (and in certain circumstances existing clients/associates) to comply with anti-money laundering regulations, ‘right to work’ and other legislative requirements applicable to Codurance;</li>
                 <li>To comply with law enforcement.</li>
+                <li>To contact you about a submisison you have mades to the websites, including any content you provide;</li>
+                <li>To personalise the way contentful content is presented to you. IP addresses are used to identify the location of users, the number of visists from different countries and also to block disruptive use and to analyse and improve the services offered on Codurance websites e.g. to provide you with the most user-friendly navigation experience; </li>
+                <li>To enable us to review, develop and improve the products, services and special offers online;</li>
+                <li>To occasionally carry out market research</li>
+                <li>To send you details of Codurance promotions, products, services, events, special offers and rewards that we think will be of interest to you. It's up to you to decide whether or not yoy want to recieve this information.</li>
             </ul>
             <p>As described in this policy, personal information will be retained by us and will not be sold, transferred or otherwise disclosed to any third party, other than for the purpose of lawful processing. Personal information may be anonymised / pseudonymised for the purpose of research to inform our marketing and development strategies or where such disclosure is required by law or court order.</p>
             <p>If your personal information changes or you no longer wish to receive a particular communication from us please let us know and we will correct, update or remove your details. This can be done by emailing privacy@codurance.com</p>
@@ -63,19 +68,6 @@ title: Privacy Policy
             <h4>Codurance uses cookies and collects IP addresses</h4>
             <p>Cookies are small pieces of information stored by your internet browser on to your computer's hard drive. Like most website providers, Codurance uses cookies to enable us to make a link between you and the information you have provided to our website and therefore provide you with personalised content so that we can give you a better experience when you return. Most web browsers automatically accept cookies, although you can choose not to.</p>
             <p>An IP address is a number that can uniquely identify a specific computer or other network device on the internet. We use analysis software to look at IP addresses and cookies for the purpose of enhancing your user experience. This information is not used to develop a personal profile of you and the log files are regularly purged. To find out more about cookies and how to delete them, please visit <a href="http://www.aboutcookies.org/">http://www.aboutcookies.org/</a>, also you can view our <a href="{{ '/policies/cookie' | prepend: site.baseurl }}">Cookie Policy</a>.</p>
-        </div>
-        <div class="margin-bottom-30">
-            <h4>How will Codurance use the information they collect about me?</h4>
-            <p>Codurance will use your personal information for a number of purposes including the following:</p>
-            <ul>
-                <li>for "service administration purposes", which means that Codurance may contact you for reasons related to the service you have signed up for (e.g. to provide you with password reminders or to notify you that a particular service has been suspended for maintenance);</li>
-                <li>to contact you about a submission you have made to the websites, including any content you provide;</li>
-                <li>to personalise the way Codurance content is presented to you. IP addresses are used to identify the location of users, the number of visits from different countries and also to block disruptive use and to analyse and improve the services offered on Codurance websites e.g. to provide you with the most user-friendly navigation experience;</li>
-                <li>to enable us to review, develop and improve the products, services and special offers online;</li>
-                <li>to occasionally carry out market research</li>
-                <li>to send you details of Codurance promotions, products, services, events, special offers and rewards that we think will be of interest to you. It's up to you to decide whether or not you want to receive this information.</li>
-            </ul>
-            <p>Where Codurance proposes using your personal information for any other uses we will ensure that we notify you first. You will also be given the opportunity to withhold or withdraw your consent for your use other than as listed above.</p>
         </div>
         <div class="margin-bottom-30">
             <h4>When will Codurance contact me?</h4>


### PR DESCRIPTION
This is an update of the privacy policy to add events.

This will allow us to share this across codurance.com and sc-london.com

We can't go live with this until privacy@codurance.com exists.