### PR TITLE
Fix: removing images with text and unnecessary alternative texts

### DIFF
--- a/src/_posts/2017-09-01-do-we-have-a-good-safety-net-to-change-this-legacy-code.md
+++ b/src/_posts/2017-09-01-do-we-have-a-good-safety-net-to-change-this-legacy-code.md
@@ -36,14 +36,14 @@ So, we should aim at killing every mutation with tests.
 When I heard about it I thought about that game I played when I was just a teenager: _Super Pang_.
 
 <center>
-<img src="{{site.baseurl}}/assets/custom/img/blog/2017-09-01-coverage/super-pang-game.jpg" alt="Super Pang Game" class="img img-fluid"/>
+<img src="{{site.baseurl}}/assets/custom/img/blog/2017-09-01-coverage/super-pang-game.jpg" alt="" class="img img-fluid"/>
 </center>
 <br/>
 
-And I imagined a situation such as this:
+And I imagined the following situation: balls are mutations of our production code and the child tries to break those balls with tests rays. Tests must be good enough to detect the balls and to break them.
 
 <center>
-<img src="{{site.baseurl}}/assets/custom/img/blog/2017-09-01-coverage/super-pang-mutation-testing.jpg" alt="Super Pang - Mutation Testing" class="img img-fluid"/>
+<img src="{{site.baseurl}}/assets/custom/img/blog/2017-09-01-coverage/super-pang-mutation-testing.jpg" alt="" class="img img-fluid"/>
 </center>
 
 It’s called **mutation testing** and it's a good way to make sure that you have a good safety net with your current tests to refactor production code or to add new features. It is as if you test your tests in order to get more information about their suitability.
@@ -60,15 +60,18 @@ status arg3 = ((from.getParam1() < from.getParam2())? BLACK: WHITE);
 
 If we don’t have a test which considers the same value for `param1` and `param2`, a mutation will survive when applying <a href="http://pitest.org/quickstart/mutators/#CONDITIONALS_BOUNDARY" target="_blank">_Conditional Boundary Mutator_</a>:
 
-<center>
-<img src="{{site.baseurl}}/assets/custom/img/blog/2017-09-01-coverage/survived-mutation.png" alt="Survived mutation" class="img img-fluid"/>
-</center>
-<br/>
+```
+org.pitest.mutationtest.engine.gregor.mutators.ConditionalsBoundaryMutator
+Generated 1 Killed 0 (0%)
+KILLED 0 SURVIVED 1 TIMED_OUT 0 NON_VIABLE 0 
+MEMORY_ERROR 0 NOT_STARTED 0 STARTED 0 RUN_ERROR 0 
+NO_COVERAGE 0
+```
 
-PIT report shows the affected line:
+PIT report shows the affected line.
 
 <center>
-<img src="{{site.baseurl}}/assets/custom/img/blog/2017-09-01-coverage/pit-report-boundaries.jpg" alt="PIT Report" class="img img-fluid"/>
+<img src="{{site.baseurl}}/assets/custom/img/blog/2017-09-01-coverage/pit-report-boundaries.jpg" alt="" class="img img-fluid"/>
 </center>
 <br/>
 
@@ -80,10 +83,10 @@ It’s common to find `equals` and `hashCode` methods in Java which are only use
 
 For example, a property is added to a class without updating `equals` and `hashCode` methods, so PIT statistics results in:
 
-<center>
-<img src="{{site.baseurl}}/assets/custom/img/blog/2017-09-01-coverage/pit-statistics.png" alt="PIT Statistics" class="img img-fluid"/>
-</center>
-<br/>
+```
+Generated 15 mutations Killed 6 (40%)
+Ran 24 tests (1.6 tests per mutation)
+```
 
 And PIT report alerts on `equals` and `hashCode` methods.
 
@@ -95,10 +98,10 @@ assertTrue(reflectionEquals(actualObject, expectedObject));
 
 In that case, we can succeed in killing every mutation:
 
-<center>
-<img src="{{site.baseurl}}/assets/custom/img/blog/2017-09-01-coverage/new-pit-statistics.png" alt="PIT Statistics" class="img img-fluid"/>
-</center>
-<br/>
+```
+Generated 5 mutations Killed 5 (100%)
+Ran 7 tests (1.4 tests per mutation)
+```
 
 Another option could be to use <a href="http://joel-costigliola.github.io/assertj/assertj-core-features-highlight.html#field-by-field-comparison" target="_blank">field by field comparisons</a> from <a href="http://joel-costigliola.github.io/assertj/index.html" target="_blank">AssertJ</a>. It's useful if the object under comparison has other custom objects as properties, so comparators for types can be added by <a href="http://joel-costigliola.github.io/assertj/assertj-core-features-highlight.html#field-by-field-recursive" target="_blank">`usingComparatorForType`</a>. 
 


### PR DESCRIPTION
Hi colleagues, I made several mistakes when writing my posts. I hope this is the last one in order not to disturb you. 
In this case, I'm removing images with text and unnecessary alternative texts (an empty alt attribute is valid when it's not necessary to provide the information of the existence of that image). 
Thanks in advance!