### PR TITLE
Fix bookmark links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Setup the <del>development</del> writing environment 
 
-You can serve the site through [docker](#installing-if-you-like-docker) or [natively](#installing-if-you-like-ruby) on your machine.
+You can serve the site through [docker](#building-if-you-like-docker) or [natively](#building-if-you-like-ruby) on your machine.
 
 ### Building if you like Docker
 


### PR DESCRIPTION
The titles had changed from "Installing" to "Building". Updated the links to reflect this.