### PR TITLE
Remove Google Plus share icon

### DIFF
--- a/src/_includes/social_icons.html
+++ b/src/_includes/social_icons.html
@@ -14,12 +14,6 @@
             </a>
         </li>
         <li class="list-inline-item g-mx-2">
-            <a class="u-icon-v1 u-icon-slide-up--hover g-color-gray-dark-v4 g-color-google-plus--hover" href="https://plus.google.com/share?url={{ site.url }}{{ site.baseurl }}{{ page.url }}">
-                <i class="g-font-size-default g-line-height-1 u-icon__elem-regular fa fa-google-plus"></i>
-                <i class="g-font-size-default g-line-height-0_8 u-icon__elem-hover fa fa-google-plus"></i>
-            </a>
-        </li>
-        <li class="list-inline-item g-mx-2">
             <a class="u-icon-v1 u-icon-slide-up--hover g-color-gray-dark-v4 g-color-linkedin--hover" href="http://www.linkedin.com/shareArticle?mini=true&title={{ page.title }}&summary={{ page.abstract }}&url={{ site.url }}{{ site.baseurl }}{{ page.url }}">
                 <i class="g-font-size-default g-line-height-1 u-icon__elem-regular fa fa-linkedin"></i>
                 <i class="g-font-size-default g-line-height-0_8 u-icon__elem-hover fa fa-linkedin"></i>


### PR DESCRIPTION
Remove the Google+ share link at the bottom of posts etc, since Google+ has been [shut down](https://support.google.com/plus/answer/9217723?hl=en-GB) for personal use and is now only available with G Suite accounts.