### PR TITLE
Link the trello board from the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # [Codurance Web Site](https://codurance.com/)
+Trello board: https://trello.com/b/Z6YDy6bw/2018-website-project
 
 ## Setup the <del>development</del> writing environment 
 


### PR DESCRIPTION
When I did research on the codurance site I found the Projects board tab to be abandoned so I did my own backlog of proposed changes. It was 1 week after this that Alfredo told me about the existence of this trello board. 
Adding a link to the trello in the README.md can prevent this to occur again. Also it'd be good to delete the github "projects" board. 