### PR TITLE
Removes SC London 2019 banner as well as JS only used by banner from page

### DIFF
--- a/src/_includes/foot.html
+++ b/src/_includes/foot.html
@@ -99,8 +99,6 @@
 
   <script src="{{ '/assets/custom/js/cookie-message.js' | prepend: site.baseurl }}"></script>
 
-  <script src="{{ '/assets/custom/js/persisted-closable.js' | prepend: site.baseurl }}"></script>
-
   <!-- Start of Google analytics configuration -->
   <script>
     if(codurance.cookieMessage.hasConsent()) {

--- a/src/_includes/publication.html
+++ b/src/_includes/publication.html
@@ -23,8 +23,6 @@
     </div>
 </section>
 
-{% include mid_banner_ad.html %}
-
 <section class="container">
     <div class="row">
         <div class="col-lg-9 container">


### PR DESCRIPTION
Note I've left the files in place, as I'm assuming we'll want to reuse this banner ad capability, if not for SC London 2020 then for something else.