### PR TITLE
Add youtube to social icons

### DIFF
--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -154,22 +154,22 @@
             </a>
           </li>
           <li class="list-inline-item g-mx-10" data-toggle="tooltip" data-placement="top" title="Facebook">
-            <a href="https://www.facebook.com/codurance/" class="g-color-white-opacity-0_5 g-color-white--hover">
+            <a href="https://www.facebook.com/codurance/" target="_blank" class="g-color-white-opacity-0_5 g-color-white--hover">
               <i class="fa fa-facebook"></i>
             </a>
           </li>
           <li class="list-inline-item g-mx-10" data-toggle="tooltip" data-placement="top" title="Linkedin">
-            <a href="https://www.linkedin.com/company/codurance" class="g-color-white-opacity-0_5 g-color-white--hover">
+            <a href="https://www.linkedin.com/company/codurance" target="_blank" class="g-color-white-opacity-0_5 g-color-white--hover">
               <i class="fa fa-linkedin"></i>
             </a>
           </li>
           <li class="list-inline-item g-mx-10" data-toggle="tooltip" data-placement="top" title="Twitter">
-            <a href="https://twitter.com/codurance" class="g-color-white-opacity-0_5 g-color-white--hover">
+            <a href="https://twitter.com/codurance" target="_blank" class="g-color-white-opacity-0_5 g-color-white--hover">
               <i class="fa fa-twitter"></i>
             </a>
           </li>
           <li class="list-inline-item g-mx-10" data-toggle="tooltip" data-placement="top" title="Instagram">
-            <a href="https://www.instagram.com/codurance/" class="g-color-white-opacity-0_5 g-color-white--hover">
+            <a href="https://www.instagram.com/codurance/" target="_blank" class="g-color-white-opacity-0_5 g-color-white--hover">
               <i class="fa fa-instagram"></i>
             </a>
           </li>

--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -148,6 +148,11 @@
 
       <div class="col-md-4 align-self-center">
         <ul class="list-inline text-center text-md-right mb-0">
+          <li class="list-inline-item g-mx-10" data-toggle="tooltip" data-placement="top" title="YouTube">
+            <a href="https://www.youtube.com/user/codurance" class="g-color-white-opacity-0_5 g-color-white--hover">
+              <i class="fa fa-youtube"></i>
+            </a>
+          </li>
           <li class="list-inline-item g-mx-10" data-toggle="tooltip" data-placement="top" title="Facebook">
             <a href="https://www.facebook.com/codurance/" class="g-color-white-opacity-0_5 g-color-white--hover">
               <i class="fa fa-facebook"></i>


### PR DESCRIPTION
Added YouTube icon to the social icons in the footer.
Also added target="_blank" to all the social icons so when people click a new tab is opened rather than re-directing away from the Codurance site.

The icon looks a bit rubbish given the size of the icons and what we have to work with from the icon set in the unify templates.
Maybe making all the icons a little bigger may help with the look.