### PR TITLE
Fix the cta's to our Services page

### DIFF
--- a/src/services/_includes/we_advise_coach_deliver.html
+++ b/src/services/_includes/we_advise_coach_deliver.html
@@ -10,21 +10,12 @@
       <div class="col-sm-6 col-lg-3 g-mb-20">
         <div class="text-center">
           <i class="g-mb-20">
-            <img
-              class="icon-large"
-              src="{{ '/assets/custom/img/home/icon-delivery-capability.svg' | prepend: site.baseurl }}"
-            />
+            <img class="icon-large" src="{{ '/assets/custom/img/home/icon-delivery-capability.svg' | prepend: site.baseurl }}" />
           </i>
-          <h3
-            class="u-text-icon g-mb-25 g-ml-15 g-mr-15 g-font-weight-600"
-            style="height: 80px;"
-          >
+          <h3 class="u-text-icon g-mb-25 g-ml-15 g-mr-15 g-font-weight-600" style="height: 80px;" >
             {%t services.we-advise-subtitle %}
           </h3>
-          <a
-            class="btn btn-more"
-            href="{{ '/services/#we-advise' | prepend: site.baseurl }}"
-          >
+          <a class="btn btn-more" href="{{ '/services/#we-advise' | prepend: site.baseurl }}" >
             <span>{%t services.learn-more %}</span>
           </a>
         </div>
@@ -33,21 +24,12 @@
       <div class="col-sm-6 col-lg-3 g-mb-20">
         <div class="text-center">
           <i class="g-mb-20">
-            <img
-              class="icon-large"
-              src="{{ '/assets/custom/img/home/icon-coaching.svg' | prepend: site.baseurl }}"
-            />
+            <img class="icon-large" src="{{ '/assets/custom/img/home/icon-coaching.svg' | prepend: site.baseurl }}" />
           </i>
-          <h3
-            class="u-text-icon g-mb-25 g-ml-15 g-mr-15 g-font-weight-600"
-            style="height: 80px;"
-          >
+          <h3 class="u-text-icon g-mb-25 g-ml-15 g-mr-15 g-font-weight-600" style="height: 80px;" >
             {%t services.we-coach-subtitle %}
           </h3>
-          <a
-            class="btn btn-more"
-            href="{{ '/services/#we-advise' | prepend: site.baseurl }}"
-          >
+          <a class="btn btn-more" href="{{ '/services/#we-coach' | prepend: site.baseurl }}" >
             <span>{%t services.learn-more %}</span>
           </a>
         </div>
@@ -56,21 +38,12 @@
       <div class="col-sm-6 col-lg-3 g-mb-20">
         <div class="text-center">
           <i class="g-mb-20">
-            <img
-              class="icon-large"
-              src="{{ '/assets/custom/img/home/icon-quality-software.svg' | prepend: site.baseurl }}"
-            />
+            <img class="icon-large" src="{{ '/assets/custom/img/home/icon-quality-software.svg' | prepend: site.baseurl }}" />
           </i>
-          <h3
-            class="u-text-icon g-mb-25 g-ml-15 g-mr-15 g-font-weight-600"
-            style="height: 80px;"
-          >
+          <h3 class="u-text-icon g-mb-25 g-ml-15 g-mr-15 g-font-weight-600" style="height: 80px;" >
             {%t services.we-deliver-subtitle %}
           </h3>
-          <a
-            class="btn btn-more"
-            href="{{ '/services/#we-advise' | prepend: site.baseurl }}"
-          >
+          <a class="btn btn-more" href="{{ '/services/#we-deliver' | prepend: site.baseurl }}" >
             <span>{%t services.learn-more %}</span>
           </a>
         </div>


### PR DESCRIPTION
These links all linked to the 'We Advise' section of our Services page. Now they link to their relevant sections within the Services page.