### PR TITLE
Redirect Sandro's profile link + fix broken link in blog post

### DIFF
--- a/src/_posts/2019-04-30-state-of-the-art-jenkins-github-docker.md
+++ b/src/_posts/2019-04-30-state-of-the-art-jenkins-github-docker.md
@@ -22,7 +22,7 @@ For the last two years I've worked on a Node.js project. We used GitHub for sour
 
 We have done a few improvements to the configuration during this time. One of the changes that had a positive impact was to run the CI pipeline on branches and to see the feedback in GitHub.
 
-Checking the outcome of the build before merging a PR prevented a lot of breakages due to tiny mistakes. Like forgetting to run the linter or to add a new file. Once we decided to automate the update of dependencies the feedback made it quick and safe. Read [Taming dependabot by Christopher Eyre]({{ site.baseurl }}/2019/02/29/taming-dependabot)) for that part of the story.
+Checking the outcome of the build before merging a PR prevented a lot of breakages due to tiny mistakes. Like forgetting to run the linter or to add a new file. Once we decided to automate the update of dependencies the feedback made it quick and safe. Read [Taming dependabot by Christopher Eyre]({{ site.baseurl }}/2019/02/24/taming-dependabot)) for that part of the story.
 
 
 In this post I'm going to explain how to configure a Continuos Integration and Deployment Pipeline using:

--- a/src/blog/author/sandro-mancuso.html
+++ b/src/blog/author/sandro-mancuso.html
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: /blog/author/sandro-mancuso/
+redirect_to: /publications/author/sandro-mancuso/
+---


### PR DESCRIPTION
Redirect https://codurance.com/blog/author/sandro-mancuso to https://codurance.com/publications/author/sandro-mancuso.

We added a directory `blog/author` with `sandro-mancuso.html` that redirects to /publications/...
The blog/author pages are dynamically generated, so we can't use `redirect-from`. Therefore we added this file in order to use `redirect_to`.

The other broken link was just a problem of dates.
