### PR TITLE
Avoid toggles being changed from local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ tools/snapshots/backstop_data/*
 output/*
 
 coverage/*
+
+toggles.yml

--- a/README.md
+++ b/README.md
@@ -287,16 +287,29 @@ The second runs it against the local version of the site (locahost:4000) and com
 
 We are using [toggles.yml](src/_data/toggles.yml) to set toggles to "on" or "off". This file is in `.gitignore` so you can set change values locally without risk of commiting them accidentally. 
 
+First add a file `src/_data/toggles.yml` and include your feature toggle settings, e.g.
+
+```yml
+feature-my-feature: "on"
+feature-some-other-feature: "off"
+```
+
+A similar file exists in the repo on GitHub with it's own settings.
+
 ### Toggle a feature on in Production
 
-Make changes to feature toggles for Production by [editing toggles.yml](https://github.com/codurance/site/edit/master/src/_data/toggles.yml) via the GitHub and commiting to `master` or via a pull request. Assuming this triggers a rebuild and redeploy this should toggle your feature.
+Make changes to feature toggles for Production by [editing the toggles.yml on GitHub](https://github.com/codurance/site/edit/master/src/_data/toggles.yml) and commiting it to `master` directly or via a pull request. Assuming this commit triggers a rebuild and redeploy your changes should take affect.
 
 ### Using the feature toggle
 
-The simplest thing is a simple conditional:
+The simplest implimentation is a simple conditional:
 
 ```liquid
 {% if site.data.toggles.my-feature == 'on' %}
   {% include my-component.html %}
 {% endif %}
 ```
+
+### Tidy up
+
+It should go without saying that once a feature has been switched on in production and is considered stable the toggle should be removed from the codebase.

--- a/README.md
+++ b/README.md
@@ -282,3 +282,21 @@ backstop test
 
 The first captures a snapshot of the reference site (currently set to https://codurance.com)
 The second runs it against the local version of the site (locahost:4000) and compares the differences.
+
+## Feature Toggles
+
+We are using [toggles.yml](src/_data/toggles.yml) to set toggles to "on" or "off". This file is in `.gitignore` so you can set change values locally without risk of commiting them accidentally. 
+
+### Toggle a feature on in Production
+
+Make changes to feature toggles for Production by [editing toggles.yml](https://github.com/codurance/site/edit/master/src/_data/toggles.yml) via the GitHub and commiting to `master` or via a pull request. Assuming this triggers a rebuild and redeploy this should toggle your feature.
+
+### Using the feature toggle
+
+The simplest thing is a simple conditional:
+
+```liquid
+{% if site.data.toggles.my-feature == 'on' %}
+  {% include my-component.html %}
+{% endif %}
+```

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ The second runs it against the local version of the site (locahost:4000) and com
 
 ## Feature Toggles
 
-We are using [toggles.yml](src/_data/toggles.yml) to set toggles to "on" or "off". This file is in `.gitignore` so you can set change values locally without risk of commiting them accidentally. 
+We are using [toggles.yml](src/_data/toggles.yml) to set toggles to "on" or "off". This file is in `.gitignore` so you can change values locally without risk of commiting the changes accidentally. 
 
 First add a file `src/_data/toggles.yml` and include your feature toggle settings, e.g.
 

--- a/src/_data/toggles.yml
+++ b/src/_data/toggles.yml
@@ -1,1 +1,0 @@
-feature-sm-blogs: "off"


### PR DESCRIPTION
To:
- make it harder to accidentally change a feature toggle that affects prod and 
- make it safer to change a feature toggle locally

This PR also contains addtions to the README

@keith-smale @Dan-Bird
Following approval and merge of this PR we should create a fresh `src/_data/toggles.yml` via GitHub with the following contents:

```yml
feature-sm-blogs: "off"
```

This is not necessary but would be helpfully, ready for when we need to turn the first feature on.

_Reviews from all Codurance welcome!_