### PR TITLE
Provide a quicker Rake script

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,11 @@ Install [Ruby Version Manager](https://rvm.io/), Ruby and Bundler:
 Now run Bundler and serve the site locally:
 
 - `bundle install`
-- `rake servequick`
+- `rake servequick`\*
 
 The site should now be running on http://localhost:4000
+
+_\*`rake serve_quicker` is also available which rebuilds faster by only rebuilding the EN language website._
 
 In case of problems, refer to the [troubleshooting section](#troubleshooting).
 
@@ -285,7 +287,7 @@ The second runs it against the local version of the site (locahost:4000) and com
 
 ## Feature Toggles
 
-We are using [toggles.yml](src/_data/toggles.yml) to set toggles "on" or "off". 
+We are using [toggles.yml](src/_data/toggles.yml) to set toggles "on" or "off".
 
 ```yml
 feature-my-feature: "on"

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,7 @@ end
 
 multitask serve:      [:_build_en,       :_build_es,       :_ruby_serve]
 multitask servequick: [:_build_en_quick, :_build_es_quick, :_ruby_serve]
+multitask serve_quicker: [:_build_en_quick, :_ruby_serve]
 
 task :_build_en_quick do
   sh 'bundle exec jekyll build --config build/config/_config.yml,build/config/_config_en.yml --watch --destination output/_site/en --baseurl /en  --limit_posts 10'


### PR DESCRIPTION
These changes add new Rake script called `serve_quicker` that runs a few seconds faster than `servequick`

I've been using it today and rebuilds in response to JS, HTML and CSS changes are taking approx. 9-10 seconds. Yesterday and using `quickserve` similar changes were taking 12-18 seconds. It's not much of a difference but it all adds up.

`servequick` is still available because it rebuilds both languages. The quicker script is quicker because it only rebuilds one language.