### PR TITLE
added software modernisation tag to posts and podcasts

### DIFF
--- a/src/_podcasts/2019-01-21-legacy-code.md
+++ b/src/_podcasts/2019-01-21-legacy-code.md
@@ -8,6 +8,8 @@ image:
 title: "Codurance Talks - Episode 8 - Legacy Code"
 video-url: https://www.podbean.com/media/player/2yuxa-a53d35?from=yiiadmin&download=1&version=1&vjs=1&skin=1&auto=0&share=1&fonts=Helvetica&download=1&rtl=0
 date: 2019-01-21 12:00:00 +00:00
+tags:
+- software modernisation
 ---
 
 New Year, new podcast available. It is time to talk about Legacy Code. [Sam Davies](https://codurance.com/publications/author/sam-davies/) and [Chris Bimson](https://github.com/christopher-bimson) return, with the new addition of [Andre Torres](https://github.com/andre2w), who this time took charge of the editing.

--- a/src/_podcasts/2019-11-18-value-stram-mapping.md
+++ b/src/_podcasts/2019-11-18-value-stram-mapping.md
@@ -8,6 +8,8 @@ image:
 title: "Codurance Talks - Episode 18 - Value Stream Mapping"
 video-url: https://www.podbean.com/media/player/3nejq-c7d5ef?from=yiiadmin&download=1&version=1&vjs=1&skin=1&auto=0&share=1&fonts=Helvetica&download=1&rtl=0&pbad=1
 date: 2019-11-18 06:00:00 +00:00
+tags:
+- software modernisation
 ---
 
 On this episode [Solange](https://codurance.com/publications/author/solange-u.-gasengayire/) hosts a talk around Value Stream Mapping. [Jorge](https://codurance.com/publications/author/jorge-gueorguiev-garcia/) co-hosts, while [Mash](https://codurance.com/publications/author/mashooq-badar/) and [Chris](https://github.com/christopher-bimson) provide the knowledge.

--- a/src/_posts/2011-06-21-change-in-attitude-legacy-code.md
+++ b/src/_posts/2011-06-21-change-in-attitude-legacy-code.md
@@ -4,6 +4,8 @@ layout: post
 name: change-in-attitude-legacy-code
 title: "A change in attitude - Legacy code"
 date: 2011-06-21 03:31:00 +01:00
+tags:
+- software modernisation
 ---
 
 <blockquote>Attitude is a little thing that makes a big difference.

--- a/src/_posts/2012-08-14-encouraging-collaboration-via-design-committee.md
+++ b/src/_posts/2012-08-14-encouraging-collaboration-via-design-committee.md
@@ -10,6 +10,8 @@ categories:
 - process
 image:
     src: http://mashb.files.wordpress.com/2012/08/125072659262p56k.jpg
+tags:
+- software modernisation
 ---
 
 Agile process promotes the view that system design emerges and evolves throughout it's life. It is a result of continuos discussions and decisions by the teams.

--- a/src/_posts/2012-08-15-the-best-approach-to-software.md
+++ b/src/_posts/2012-08-15-the-best-approach-to-software.md
@@ -4,6 +4,8 @@ layout: post
 name: the-best-approach-to-software
 title: "The best approach to software development"
 date: 2012-08-15 04:08:00 +01:00
+tags:
+- software modernisation
 ---
 
 

--- a/src/_posts/2012-12-10-the-wrong-notion-of-time.md
+++ b/src/_posts/2012-12-10-the-wrong-notion-of-time.md
@@ -8,6 +8,7 @@ image:
     src: /assets/custom/img/blog/wrong-time.jpeg
 tags:
 - craftsmanship
+- software modernisation
 ---
 
 No one wakes up in the morning and say "Today I'm gonna screw up. Today

--- a/src/_posts/2014-11-10-not-all-managers-are-stupid.md
+++ b/src/_posts/2014-11-10-not-all-managers-are-stupid.md
@@ -11,6 +11,7 @@ tags:
 - agile
 - teams
 - managers
+- software modernisation
 ---
 
 _(The following story was a bit altered in order to keep it short(ish) and to protect the innocents)_

--- a/src/_posts/2014-12-14-quality-cannot-be-measured.md
+++ b/src/_posts/2014-12-14-quality-cannot-be-measured.md
@@ -12,6 +12,7 @@ tags:
 - test-driven-development
 - quality
 - metrics
+- software modernisation
 ---
 
 We cannot effectively measure what we can't precisely define. And this is definitely true when it comes to software quality. What is software quality? What does quality mean? Quality for whom? Compared to what? In which context? Are we talking about quality from a developer's perspective, from a manager's perspective, or from a user's perspective?

--- a/src/_posts/2015-03-23-project-sizing.md
+++ b/src/_posts/2015-03-23-project-sizing.md
@@ -11,6 +11,7 @@ tags:
 - agile
 - codurance-way
 - backlog
+- software modernisation
 ---
 Sizing a project is one of the most important things we do and it is often the first thing we need precisely when we have the least amount of information. During a pre-sales meeting the client will usually ask for a "ballpark" figure so that they can understand if the project is feasible. We try to get as much information as possible before we provide a very high-level figure. The approach we take depends on whether the client already has a well defined backlog or if they are expecting us to create the backlog as part of the estimation. 
 

--- a/src/_posts/2015-05-09-does-tdd-lead-to-good-design.md
+++ b/src/_posts/2015-05-09-does-tdd-lead-to-good-design.md
@@ -11,6 +11,7 @@ tags:
 - quality
 - TDD
 - design
+- software modernisation
 ---
 
 Recently I tweeted that [TDD can’t lead to a good design if we don’t know what good design looks like](https://twitter.com/sandromancuso/status/588503877235781632). I was also saying that we probably should teach design before TDD (or at least, at the same time). This tweet led to a discussions with [J.B. Rainsberger](https://twitter.com/jbrains), [Ron Jeffries](https://twitter.com/RonJeffries), and a few others. J.B. and I ended up having a live [discussion on Hangout on Air](https://www.youtube.com/watch?v=ty3p5VDcoOI) later on. 

--- a/src/_posts/2015-08-05-becoming-evergreen.md
+++ b/src/_posts/2015-08-05-becoming-evergreen.md
@@ -9,6 +9,8 @@ image:
     attribution:
         text: Evergreen, by Dan Cook
         href: https://flic.kr/p/dtRXDQ
+tags:
+- software modernisation
 ---
 
 > “It is only when the cold season comes that we know the Pine and Cypress to be evergreens.” - *Chinese Proverb*

--- a/src/_posts/2016-07-25-thoughts-on-coupling-in-software-design.md
+++ b/src/_posts/2016-07-25-thoughts-on-coupling-in-software-design.md
@@ -11,6 +11,7 @@ tags:
 - coupling
 - software design
 - craftsmanship
+- software modernisation
 categories:
 - software-creation
 ---

--- a/src/_posts/2019-01-15-codurance-gain-aws-partner-status.md
+++ b/src/_posts/2019-01-15-codurance-gain-aws-partner-status.md
@@ -14,6 +14,7 @@ tags:
 - cloud 
 - partnerships 
 - aws
+- software modernisation
 ---
 
 ### We are pleased to announce that Codurance has achieved [AWS Consulting Partner status](https://aws.amazon.com/partners/find/partnerdetails/?n=Codurance%20Ltd&id=001E000001dA58LIAS) in the AWS Partner Network. This status recognises the expertise, skill and experience of our people in the [AWS Cloud](https://aws.amazon.com/) ecosystem and its various services.


### PR DESCRIPTION
Added a new 'software modernisation' tag to some existing posts and podcasts.

When searching the tag the posts are shown but the podcasts are not (raised issue https://github.com/codurance/site/issues/1718 to review and resolve)