### PR TITLE
Compress some of our CSS

### DIFF
--- a/build/config/_config.yml
+++ b/build/config/_config.yml
@@ -66,6 +66,7 @@ default_post_image: "/assets/custom/img/home/computerdesk_original_opt_bw.jpg"
 
 sass:
   sass_dir: assets/custom/css/_sass
+  style: compressed
 
 languages: ["en", "es"]
 


### PR DESCRIPTION
Turns out we can compress the SCSS that's being handled by Jeykll simply by passing the `compressed` [Sass style](https://sass-lang.com/documentation/cli/dart-sass#style) in our `build/config`.

At the moment this won't have much affect (around 49kB becomes 33KB). This is because only the custom CSS that we've put into SCSS files is being compressed. We still have around 2MB of CSS (uncompressed) being downloaded with out website. However, it does mean that as we start to remove third party CSS or move it into our SCSS files our the download for the end user will be that bit faster and Googlebots will look on us with that bit more respect
