### PR TITLE
Add breakpoint mixins

### DIFF
--- a/src/assets/custom/css/_sass/_breakpoint-demo.scss
+++ b/src/assets/custom/css/_sass/_breakpoint-demo.scss
@@ -1,0 +1,49 @@
+.breakpoint-demo {
+  font-size: 1rem;
+  margin: 1rem;
+  padding: 0.5rem;
+
+  @include small {
+    &:after {
+      content: ": small";
+    }
+  }
+
+  @include small-and-medium {
+    border-bottom: 0.125rem solid red;
+  }
+
+  @include small-medium-and-large {
+    border-right: 0.125rem solid yellow;
+  }
+
+  @include medium {
+    &:after {
+      content: ": medium";
+    }
+  }
+
+  @include medium-and-large {
+    border-left: 0.25rem solid cyan;
+  }
+
+  @include medium-large-and-extra-large {
+    border-top: 0.25rem solid lime;
+  }
+
+  @include large {
+    &:after {
+      content: ": large";
+    }
+  }
+
+  @include large-and-extra-large {
+    border-bottom: 0.3rem solid red;
+  }
+
+  @include extra-large {
+    &:after {
+      content: ": extra-large";
+    }
+  }
+}

--- a/src/assets/custom/css/_sass/_breakpoints.scss
+++ b/src/assets/custom/css/_sass/_breakpoints.scss
@@ -1,0 +1,60 @@
+$smallMax: 767px;
+$mediumMin: 768px;
+$mediumMax: 1023px;
+$largeMin: 1024px;
+$largeMax: 1199px;
+$extraLargeMin: 1200px;
+
+@mixin small {
+  @media (max-width: $smallMax) {
+    @content;
+  }
+}
+
+@mixin small-and-medium {
+  @media (max-width: $mediumMax) {
+    @content;
+  }
+}
+
+@mixin small-medium-and-large {
+  @media (max-width: $largeMax) {
+    @content;
+  }
+}
+
+@mixin medium {
+  @media (min-width: $mediumMin) and (max-width: $mediumMax) {
+    @content;
+  }
+}
+
+@mixin medium-and-large {
+  @media (min-width: $mediumMin) and (max-width: $largeMax) {
+    @content;
+  }
+}
+
+@mixin medium-large-and-extra-large {
+  @media (min-width: $mediumMin) {
+    @content;
+  }
+}
+
+@mixin large {
+  @media (min-width: $largeMin) and (max-width: $largeMax) {
+    @content;
+  }
+}
+
+@mixin large-and-extra-large {
+  @media (min-width: $largeMin) {
+    @content;
+  }
+}
+
+@mixin extra-large {
+  @media (min-width: $extraLargeMin) {
+    @content;
+  }
+}

--- a/src/assets/custom/css/_sass/_breakpoints.scss
+++ b/src/assets/custom/css/_sass/_breakpoints.scss
@@ -1,9 +1,10 @@
-$smallMax: 767px;
 $mediumMin: 768px;
-$mediumMax: 1023px;
 $largeMin: 1024px;
-$largeMax: 1199px;
 $extraLargeMin: 1200px;
+
+$smallMax: 767px;
+$mediumMax: 1023px;
+$largeMax: 1199px;
 
 @mixin small {
   @media (max-width: $smallMax) {

--- a/src/assets/custom/css/main.scss
+++ b/src/assets/custom/css/main.scss
@@ -1,6 +1,7 @@
 ---
 ---
 
+@import "breakpoints";
 @import "card";
 @import "curated-publications";
 @import "cta";


### PR DESCRIPTION
The mixins provides in this PR do two things:

- make a [Generic First](https://www.smashingmagazine.com/2018/12/generic-css-mobile-first/) approach to our CSS possible.
- give us a way to start using the same media queries across the whole of the website

There are notes in [this repo's wiki](https://github.com/codurance/site/wiki) about applying the [boy scout rule](https://medium.com/@biratkirat/step-8-the-boy-scout-rule-robert-c-martin-uncle-bob-9ac839778385) to replace the other media queries that we come across with one of these new mixins. 

All the new designs will use these breakpoints.

---

To get a demo of these mixins working include the `breakpoints-demo` SCSS partial in `src/assets/custom/css/main.scss` and add an element with the class `breakpoint-demo` to an HTML file you can see in your browser. Build it locally and then drag your browser window to different widths and see the different styles being applied.

Add to **main.scss**

```scss
@import "breakpoints-demo";
```

Include in your **HTML**

```html
<div class="breakpoint-demo">BREAKPOINT DEMO</div>
```

To use the mixins in your SCSS use **[@include](https://sass-lang.com/documentation/at-rules/mixin)** followed by the name of the breakpoint:

- `small`
- `small-and-medium`
- `small-medium-and-large
- `medium`
- `medium-and-large`
- `medium-large-and-extra-large`
- `large`
- `large-and-extra-large`

**Example**

```scss
.example {
  @include small {
    font-size: 1rem;
  }

  @include medium {
    font-size: 1.25rem;
  }

  @include large-and-extra-large {
    font-size: 1.5rem;
  }
}
```

See [_breakpoint-demo.scss](https://github.com/codurance/site/blob/master/src/assets/custom/css/_sass/_breakpoint-demo.scss) for further examples of how these breakpoints can be used.

@anguspaterson @Dan-Bird @mattgraygithub @keith-smale 
