### PR TITLE
Stop storing the tag in translations

### DIFF
--- a/src/_i18n/en.yml
+++ b/src/_i18n/en.yml
@@ -793,7 +793,6 @@ software-modernisation:
 
 curated-publications:
   softmod:
-    tag: life at codurance
     intro-title: Software Modernisation Publications
     intro-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus rutrum urna sed felis semper
     

--- a/src/_i18n/es.yml
+++ b/src/_i18n/es.yml
@@ -802,7 +802,6 @@ software-modernisation:
 
 curated-publications:
   softmod:
-    tag: life at codurance
     intro-title: Software Modernisation Publications
     intro-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus rutrum urna sed felis semper
     

--- a/src/_includes/software_modernisation_curated_publications.html
+++ b/src/_includes/software_modernisation_curated_publications.html
@@ -1,3 +1,3 @@
-{% assign vars = site.translations[site.lang].curated-publications.softmod %}
+{% assign translations = site.translations[site.lang].curated-publications.softmod %}
 
-{% include curated_publications.html tag=vars.tag title=vars.intro-title description=vars.intro-description %}
+{% include curated_publications.html tag="software modernisation" title=translations.intro-title description=translations.intro-description %}


### PR DESCRIPTION
Previously we were storing the 'software modernisation' tag in both translation files. These changes fix that.

Paired with @keith-smale on this one.