### PR TITLE
Wrap definition of $site-base-url in conditional

### DIFF
--- a/src/assets/custom/css/main.scss
+++ b/src/assets/custom/css/main.scss
@@ -1,7 +1,10 @@
 ---
 ---
-
-$site-base-url: {{ site.baseurl }};
+{% if site.baseurl %}
+    $site-base-url: {{ site.baseurl }};
+{% else %}
+    $site-base-url: '';
+{% endif %}
 
 @import "spacing";
 @import "breakpoints";


### PR DESCRIPTION
The production builds `task :buildesprb` were breaking on a Scss syntax error. 

This only affects the builds where `site.baseurl` is not defined, which explains why the branch and PR builds passed. This change wraps the sass definition in a conditional and provides an empty string as a fallback.

@jpwenzelc @keith-smale 