### PR TITLE
Wrap possible null variable in string

### DIFF
--- a/src/assets/custom/css/main.scss
+++ b/src/assets/custom/css/main.scss
@@ -1,10 +1,7 @@
 ---
 ---
-{% if site.baseurl %}
-    $site-base-url: {{ site.baseurl }};
-{% else %}
-    $site-base-url: '';
-{% endif %}
+
+$site-base-url: "{{ site.baseurlxxx }}";
 
 @import "spacing";
 @import "breakpoints";


### PR DESCRIPTION
Ok, so this time it should really work. On production `site.baseurl` will be empty but also "truthy" so instead of the conditional we just wrap the possibly empty value in quotes so that even if it is empty it will be valid syntax.  😄 