### PR TITLE
Release Softmod Curated Publications feature

### DIFF
--- a/src/_data/toggles.yml
+++ b/src/_data/toggles.yml
@@ -1,2 +1,2 @@
-feature-sm-blogs: "off"
+feature-sm-blogs: "on"
 feature-sm-blog-in-page-banner: "on"


### PR DESCRIPTION
This change releases a new module on the Soft Mod landing page called "Curated Publications"

<img width="1680" alt="Screenshot 2020-05-05 at 17 38 43" src="https://user-images.githubusercontent.com/353044/81091739-89e87280-8ef7-11ea-83e0-594642193a5e.png">
<img width="878" alt="Screenshot 2020-05-05 at 17 41 18" src="https://user-images.githubusercontent.com/353044/81091822-a5ec1400-8ef7-11ea-8bda-38018962fa35.png">
<img width="349" alt="Screenshot 2020-05-05 at 17 40 14" src="https://user-images.githubusercontent.com/353044/81091749-8ead2680-8ef7-11ea-88d6-165c75b3891d.png">

@nicholemellekas @keith-smale @anguspaterson @Dan-Bird @sandromancuso @mashooq let's release this in the morning?

