### PR TITLE
Correct definition of View All Publications href

### DIFF
--- a/src/_includes/curated_publications.html
+++ b/src/_includes/curated_publications.html
@@ -30,7 +30,9 @@
   </div>
 
   <footer class="curated-publications__cta-space">
-    {% assign href = {{ site.baseurl }}/{{ site.tag_page_dir }}/{{ include.tag | slugify }} %}
+    {% capture href %}
+      {{ site.baseurl }}/{{ site.tag_page_dir }}/{{ include.tag | slugify }}
+    {% endcapture %}
     {% assign text = site.translations[site.lang].publications.view-all %}
     {% include cta_secondary_link.html class='curated-publications__cta' href=href text=text %}
   </footer>


### PR DESCRIPTION
This fixes a defect where we were not correctly setting the href for the link at the bottom of the Curated Publications module.

The fix uses Liquid's [`capture`](https://shopify.dev/docs/themes/liquid/reference/tags/variable-tags#capture) tag for better string interpolation.

@jpwenzelc @Dan-Bird 