### PR TITLE
Improve space for title and description of Curated Publications cards

### DIFF
--- a/src/_includes/curated_publications.html
+++ b/src/_includes/curated_publications.html
@@ -19,8 +19,10 @@
           <a class="card__image-link" href="{{ post.url | prepend: site.baseurl }}">
             <span class="card__image" style="background-image: url({{post.image.src | prepend: site.baseurl}})"></span>
           </a>
-          <h3 class="card__title">{{ article_title }}</h3>
-          <p class="card__description">{{ article_description }}</p>
+          <div class="card__main">
+            <h3 class="card__title">{{ article_title }}</h3>
+            <p class="card__description">{{ article_description }}</p>
+          </div>
           <a class="card__cta--text" href="{{ post.url | prepend: site.baseurl }}">
             {% t publications.teaser-cta %}<i class="card__cta-decoration"></i>
           </a>

--- a/src/_includes/curated_publications.html
+++ b/src/_includes/curated_publications.html
@@ -21,7 +21,9 @@
           </a>
           <div class="card__main">
             <h3 class="card__title">{{ article_title }}</h3>
-            <p class="card__description">{{ article_description }}</p>
+            <div class="card__description-fade-out">
+              <p class="card__description">{{ article_description }}</p>
+            </div>
           </div>
           <a class="card__cta--text" href="{{ post.url | prepend: site.baseurl }}">
             {% t publications.teaser-cta %}<i class="card__cta-decoration"></i>

--- a/src/assets/custom/css/_sass/_card.scss
+++ b/src/assets/custom/css/_sass/_card.scss
@@ -29,10 +29,42 @@
   overflow: hidden;
 }
 
+$line-height: 28px;
+$description-max-height: 7 * $line-height;
+
+.card__description-fade-out {
+  overflow: hidden;
+  max-height: $description-max-height;
+
+  &::before {
+    content: "";
+    float: left;
+    height: $description-max-height;
+    width: 1px;
+  }
+  &::after {
+    background-image: linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0),
+      rgb(255, 255, 255)
+    );
+    content: "";
+    float: right;
+    height: $line-height;
+    left: 100%;
+    margin-left: -50%;
+    padding-right: 1px;
+    position: relative;
+    top: #{$description-max-height - $line-height};
+    width: 50%;
+  }
+}
+
 .card__description {
   @include base-reg;
-  margin: 0 0 45px;
-  overflow: hidden;
+  float: right;
+  width: 100%;
+  margin: 0 0 0 -1px;
 }
 
 .card__cta--text {

--- a/src/assets/custom/css/_sass/_card.scss
+++ b/src/assets/custom/css/_sass/_card.scss
@@ -14,31 +14,31 @@
   background-size: cover;
   display: block;
   height: 0;
-  margin-bottom: 40px;
   padding-top: 230 / 370 * 100%;
 }
 
-$card-lateral-internal-spacing: 30px;
+.card__main {
+  padding: 30px;
+  flex-grow: 1;
+}
 
 .card__title {
   @include mercer-bold;
-  height: 70px;
-  margin: 0 $card-lateral-internal-spacing 20px;
+  margin: 0 0 20px;
+  min-height: 55px;
   overflow: hidden;
 }
 
 .card__description {
   @include base-reg;
-  height: 55px;
-  margin: 0 $card-lateral-internal-spacing 45px;
+  margin: 0 0 45px;
   overflow: hidden;
 }
 
 .card__cta--text {
   @include base-bold;
   color: $grey-dark;
-  height: 25px;
-  margin: 0 $card-lateral-internal-spacing 35px;
+  padding: 0 30px 30px;
 
   &,
   &:hover,

--- a/src/assets/custom/css/_sass/_cards-layout.scss
+++ b/src/assets/custom/css/_sass/_cards-layout.scss
@@ -3,6 +3,10 @@
   @include max-width;
 }
 
+.cards-layout__inner {
+  display: flex;
+}
+
 @include small {
   $max-width-of-cards: 370px;
 
@@ -19,6 +23,7 @@
     overflow-x: scroll;
     overflow-y: hidden;
   }
+
   .cards-layout__inner {
     max-width: $total-max-width-of-cards + $total-width-of-spacing;
     width: calc(
@@ -28,6 +33,7 @@
         ) + #{$total-width-of-spacing}
     );
   }
+
   .cards-layout__card {
     float: left;
     margin-left: $spacing-around-cards / 2;
@@ -49,7 +55,6 @@
   $space-between-cards: 27px;
 
   .cards-layout__inner {
-    display: flex;
     flex-wrap: wrap;
   }
 
@@ -72,12 +77,6 @@
     &:nth-child(5) {
       display: none;
     }
-  }
-}
-
-@include large-and-extra-large {
-  .cards-layout__inner {
-    display: flex;
   }
 }
 

--- a/src/assets/custom/css/_sass/_curated-publications.scss
+++ b/src/assets/custom/css/_sass/_curated-publications.scss
@@ -11,14 +11,10 @@
 .curated-publications__cta-space {
   @include lateral-spacing;
   text-align: center;
-
-  @include small {
-    padding-bottom: 50px;
-  }
+  padding-bottom: 50px;
   @include medium-large-and-extra-large {
     background-color: #1e2631;
-    padding-top: 225px;
-    padding-bottom: 120px;
+    padding-top: 200px;
   }
 }
 

--- a/src/assets/custom/css/_sass/_section-intro.scss
+++ b/src/assets/custom/css/_sass/_section-intro.scss
@@ -1,19 +1,8 @@
 .section-intro {
   @include lateral-spacing;
   @include max-width;
-
-  @include small {
-    padding-top: 70px;
-    padding-bottom: 65px;
-  }
-  @include medium {
-    padding-top: 95px;
-    padding-bottom: 65px;
-  }
-  @include large-and-extra-large {
-    padding-top: 145px;
-    padding-bottom: 75px;
-  }
+  padding-top: 50px;
+  padding-bottom: 50px;
 }
 
 .section-intro__title {

--- a/src/assets/custom/css/_sass/_section-intro.scss
+++ b/src/assets/custom/css/_sass/_section-intro.scss
@@ -17,7 +17,7 @@
 }
 
 .section-intro__title {
-  @include freed-bold--responsive;
+  @include mercer-bold--responsive;
   margin-top: 0;
 
   @include small {

--- a/src/assets/custom/css/_sass/_typography.scss
+++ b/src/assets/custom/css/_sass/_typography.scss
@@ -8,17 +8,21 @@
   font-weight: 400;
 }
 
+@mixin dudler {
+  font-size: 40px;
+  line-height: 2.5;
+}
+
 @mixin freed {
   font-size: 28px;
-  line-height: 38px;
+  line-height: 1.75;
 }
 
 @mixin freed--responsive {
   @include freed;
 
   @include medium-large-and-extra-large {
-    font-size: 44px;
-    line-height: 1.25;
+    @include dudler;
   }
 }
 
@@ -38,13 +42,26 @@
 }
 
 @mixin mercer {
-  font-size: 23px;
-  line-height: 33px;
+  font-size: 21px;
+  line-height: 1.313;
+}
+
+@mixin mercer-responsive {
+  @include mercer;
+
+  @include medium-large-and-extra-large {
+    @include freed;
+  }
 }
 
 @mixin mercer-bold {
   @include bold;
   @include mercer;
+}
+
+@mixin mercer-bold--responsive {
+  @include bold;
+  @include mercer-responsive;
 }
 
 @mixin mercer-reg {
@@ -61,8 +78,7 @@
   @include base;
 
   @include medium-large-and-extra-large {
-    font-size: 28px;
-    line-height: 43px;
+    @include mercer;
   }
 }
 
@@ -76,8 +92,7 @@
   @include bold;
 
   @include medium-large-and-extra-large {
-    font-size: 28px;
-    line-height: 43px;
+    @include mercer;
   }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/codurance/site/issues/1739

> Let's show the whole titles and description on a publication teaser cards

What we've done:

- Used `flex` to ensure consistent but variable heights for sections of the cards
- Reduced the font sizes to allow for more text to show
- Added a fade-out effect at the end of the descriptions when they flow onto multiple lines

Paired with @Dan-Bird and @keith-smale – further reviews and questions welcome – even after we merge