### PR TITLE
Soft mod/refine spacing

### DIFF
--- a/src/_i18n/es.yml
+++ b/src/_i18n/es.yml
@@ -185,7 +185,7 @@ publications-post:
   date_title: Publicado
 publications:
   content-type: Publicaciones
-  teaser-cta: Más información
+  teaser-cta: Continúa
   view-all: Ver todas las publicaciones
 services:
   title: Software de calidad entregado efectivamente

--- a/src/assets/custom/css/_sass/_card.scss
+++ b/src/assets/custom/css/_sass/_card.scss
@@ -40,7 +40,7 @@ $line-height: 28px;
   }
 }
 
-$description-max-height: 7 * $line-height;
+$description-max-height: 4 * $line-height;
 
 .card__description-fade-out {
   overflow: hidden;

--- a/src/assets/custom/css/_sass/_card.scss
+++ b/src/assets/custom/css/_sass/_card.scss
@@ -25,7 +25,6 @@
 $line-height: 28px;
 
 .card__title {
-  $line-height: 28px;
   @include mercer-bold;
   margin: 0 0 20px;
   overflow: hidden;

--- a/src/assets/custom/css/_sass/_card.scss
+++ b/src/assets/custom/css/_sass/_card.scss
@@ -22,14 +22,25 @@
   flex-grow: 1;
 }
 
+$line-height: 28px;
+
 .card__title {
+  $line-height: 28px;
   @include mercer-bold;
   margin: 0 0 20px;
-  min-height: 55px;
   overflow: hidden;
+
+  @include small-and-medium {
+    min-height: 2 * $line-height;
+  }
+  @include large {
+    min-height: 3 * $line-height;
+  }
+  @include extra-large {
+    min-height: 2 * $line-height;
+  }
 }
 
-$line-height: 28px;
 $description-max-height: 7 * $line-height;
 
 .card__description-fade-out {

--- a/src/assets/custom/css/_sass/_cards-layout.scss
+++ b/src/assets/custom/css/_sass/_cards-layout.scss
@@ -1,6 +1,6 @@
 .cards-layout {
   @include lateral-spacing;
-  @include max-width;
+  @include max-width--out-there;
 }
 
 .cards-layout__inner {

--- a/src/assets/custom/css/_sass/_cards-layout.scss
+++ b/src/assets/custom/css/_sass/_cards-layout.scss
@@ -108,7 +108,7 @@
 }
 
 @include extra-large {
-  $width-of-cards: 340px;
+  $width-of-cards: 370px;
   $space-between-cards: 50px;
 
   .cards-layout__card {
@@ -118,16 +118,16 @@
       margin-right: $space-between-cards / 2;
     }
 
-    &:nth-child(2),
-    &:nth-child(3) {
+    &:nth-child(2) {
       margin-left: $space-between-cards / 2;
       margin-right: $space-between-cards / 2;
     }
 
-    &:nth-child(4) {
+    &:nth-child(3) {
       margin-left: $space-between-cards / 2;
     }
 
+    &:nth-child(4),
     &:nth-child(5) {
       display: none;
     }

--- a/src/assets/custom/css/_sass/_custom-softmod-features.scss
+++ b/src/assets/custom/css/_sass/_custom-softmod-features.scss
@@ -192,26 +192,8 @@
 .container-slim {
   padding-left: 15px;
   padding-right: 15px;
-  margin-left: auto;
-  margin-right: auto;
-}
 
-@media (min-width: 768px) {
-  .container-slim {
-    max-width: 720px;
-  }
-}
-
-@media (min-width: 992px) {
-  .container-slim {
-    max-width: 800px;
-  }
-}
-
-@media (min-width: 1200px) {
-  .container-slim {
-    max-width: 800px;
-  }
+  @include max-width--column;
 }
 
 /********************************

--- a/src/assets/custom/css/_sass/_section-intro.scss
+++ b/src/assets/custom/css/_sass/_section-intro.scss
@@ -1,6 +1,6 @@
 .section-intro {
   @include lateral-spacing;
-  @include max-width;
+  @include max-width--column;
   padding-top: 50px;
   padding-bottom: 50px;
 }

--- a/src/assets/custom/css/_sass/_spacing.scss
+++ b/src/assets/custom/css/_sass/_spacing.scss
@@ -1,7 +1,22 @@
 @mixin max-width {
   margin-left: auto;
   margin-right: auto;
-  max-width: 1510px;
+}
+
+@mixin max-width--out-there {
+  @include max-width;
+  max-width: 1308px;
+}
+
+@mixin max-width--column {
+  @include max-width;
+
+  @include small-and-medium {
+    max-width: 720px;
+  }
+  @include large-and-extra-large {
+    max-width: 800px;
+  }
 }
 
 @mixin lateral-spacing {


### PR DESCRIPTION
Further refinement of publication cards to allow for long titles:

- Introduce a consistent max-widths to Soft Mod page
- Provide three lines for card titles on large screens
- Only fit three cards on extra large screens (rather than four)

@anguspaterson please review the adjusted designs

---

**Large screens** with three lines of space for the title (the cards are quite narrow on this screen size):

<img width="1164" alt="Screenshot 2020-05-06 at 19 06 39" src="https://user-images.githubusercontent.com/353044/81212474-d81b7580-8fcc-11ea-8da4-7fe819994951.png">

**Extra large screens** only show three cards to prevent cards from being too narrow:

<img width="1680" alt="Screenshot 2020-05-06 at 19 06 14" src="https://user-images.githubusercontent.com/353044/81212454-d356c180-8fcc-11ea-98f1-86bb6b4181be.png">

---

We've also changes the Spanish text for the CTA on the Publication Cards