### PR TITLE
Ignore vendor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ validation-staus.json
 .CVS
 .idea
 node_modules
+vendor
 
 # intellij idea files
 *.iml


### PR DESCRIPTION
Since upgrading to macOS Catalina I had to redo the steps to install Ruby, etc.

This time when I ran `bundle install` it generated a `vendor/` directory, so I'm offering up this change to add it to the `.gitignore`

Comments welcome from anyone more familar with the Ruby ecosystem.