### PR TITLE
Webinar Teaser - Layout refinements

### DIFF
--- a/src/_includes/soft_mod_webinar_hero_teaser.html
+++ b/src/_includes/soft_mod_webinar_hero_teaser.html
@@ -1,13 +1,11 @@
-<section class="soft-mod--hero-teaser hero-teaser">
-  <div class="hero-teaser__inner">
-    <div class="hero-teaser__image"></div>
-    <div class="hero-teaser__content">
-      <h2 class="hero-teaser__content-type">Webinar</h2>
-      <h3 class="hero-teaser__title">Software Modernisation in distributed work times</h3>
-      <p class="hero-teaser__description">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus rutrum urna sed</p>
-      {% assign href = "/software-modernisation/" | prepend: site.baseurl %}
-      {% assign text = site.translations[site.lang].software-modernisation.home-page-banner-link %}
-      {% include cta_primary_link.html color='coral' href=href text=text %}
-    </div>
+<section class="hero-teaser">
+  <div class="hero-teaser__image"></div>
+  <div class="hero-teaser__content">
+    <h2 class="hero-teaser__content-type">Webinar</h2>
+    <h3 class="hero-teaser__title">Software Modernisation in distributed work times</h3>
+    <p class="hero-teaser__description">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus rutrum urna sed</p>
+    {% assign href = "/software-modernisation/" | prepend: site.baseurl %}
+    {% assign text = site.translations[site.lang].software-modernisation.home-page-banner-link %}
+    {% include cta_primary_link.html color='coral' href=href text=text %}
   </div>
 </section>

--- a/src/_includes/soft_mod_webinar_hero_teaser.html
+++ b/src/_includes/soft_mod_webinar_hero_teaser.html
@@ -1,4 +1,4 @@
-<section class="hero-teaser">
+<section class="soft-mod--hero-teaser hero-teaser">
   <div class="hero-teaser__inner">
     <div class="hero-teaser__image"></div>
     <div class="hero-teaser__content">

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -9,10 +9,7 @@ layout: compress
 {% include head.html %}
 </head>
 
-{% if site.data.toggles.feature-soft-mod-webinar == 'on' %}
-  {% assign toggle = "feature-soft-mod-webinar" %}
-{% endif %}
-<body class="{{toggle}}">
+<body>
 
 <div class="wrapper">
 <!--=== Header ===-->

--- a/src/assets/custom/css/_sass/_curated-publications.scss
+++ b/src/assets/custom/css/_sass/_curated-publications.scss
@@ -1,7 +1,3 @@
-.curated-publications {
-  background: $sheen;
-}
-
 .curated-publications__cards {
   @include medium-large-and-extra-large {
     margin-bottom: -150px;

--- a/src/assets/custom/css/_sass/_hero-teaser.scss
+++ b/src/assets/custom/css/_sass/_hero-teaser.scss
@@ -1,10 +1,6 @@
-.hero-teaser {
-  background: $sheen;
-}
-
 $vertical-space: 100px;
 
-.hero-teaser__inner {
+.hero-teaser {
   @include max-width--out-there;
   position: relative;
 

--- a/src/assets/custom/css/_sass/_soft-mod.scss
+++ b/src/assets/custom/css/_sass/_soft-mod.scss
@@ -1,11 +1,11 @@
-body:not(.feature-soft-mod-webinar) {
-  .soft-mod__form-holder {
-    @include medium-large-and-extra-large {
-      position: relative;
-      z-index: 20;
-    }
+.soft-mod__form-holder {
+  @include medium-large-and-extra-large {
+    position: relative;
+    z-index: 20;
   }
+}
 
+body:not(.feature-soft-mod-webinar) {
   .soft-mod__curated-publications {
     @include medium-large-and-extra-large {
       margin-top: -100px;
@@ -16,3 +16,13 @@ body:not(.feature-soft-mod-webinar) {
   }
 }
 
+body.feature-soft-mod-webinar {
+  .soft-mod--hero-teaser {
+    @include medium-large-and-extra-large {
+      margin-top: -100px;
+      padding-top: 150px;
+      position: relative;
+      z-index: 10;
+    }
+  }
+}

--- a/src/assets/custom/css/_sass/_soft-mod.scss
+++ b/src/assets/custom/css/_sass/_soft-mod.scss
@@ -5,24 +5,13 @@
   }
 }
 
-body:not(.feature-soft-mod-webinar) {
-  .soft-mod__curated-publications {
-    @include medium-large-and-extra-large {
-      margin-top: -100px;
-      padding-top: 100px;
-      position: relative;
-      z-index: 10;
-    }
-  }
-}
+.soft-mod__publications {
+  background: $sheen;
 
-body.feature-soft-mod-webinar {
-  .soft-mod--hero-teaser {
-    @include medium-large-and-extra-large {
-      margin-top: -100px;
-      padding-top: 150px;
-      position: relative;
-      z-index: 10;
-    }
+  @include medium-large-and-extra-large {
+    margin-top: -100px;
+    padding-top: 100px;
+    position: relative;
+    z-index: 10;
   }
 }

--- a/src/software-modernisation/index.html
+++ b/src/software-modernisation/index.html
@@ -352,11 +352,13 @@ metarobots: index,follow
   </div>
 </section>
 
-{% if site.data.toggles.feature-soft-mod-webinar == 'on' %}
-  {% include soft_mod_webinar_hero_teaser.html %}
-{% endif %}
+<div class=soft-mod__publications>
+  {% if site.data.toggles.feature-soft-mod-webinar == 'on' %}
+    {% include soft_mod_webinar_hero_teaser.html %}
+  {% endif %}
 
-{% include soft_mod_curated_publications.html %}
+  {% include soft_mod_curated_publications.html %}
+</div>
 
 <script>
   var image = document.getElementsByClassName('img-parallax');


### PR DESCRIPTION
These two changes come out of a design review:

1. Use the same "sheen" background behind both sections, to avoid a "hard edge" where the gradient repeats itself
1. Apply the same, "pull-up" effect to the Webinar Teaser as we had with the Curated Publications section, so the form slightly overlaps this section.

See image for reference

<img width="1680" alt="Screenshot 2020-05-12 at 12 43 06" src="https://user-images.githubusercontent.com/353044/81684526-f3640600-944e-11ea-9c66-a72f7f0e6be8.png">

Dan (and anyone else) please review and ask about anything you're not sure off.

**Note** you probably want to _Hide Whitespace Changes_ when you review to make the changes in `soft_mod_webinar_hero_teaser.html` easier to read.