### PR TITLE
Publications header tweaks

### DIFF
--- a/src/_includes/publication.html
+++ b/src/_includes/publication.html
@@ -31,10 +31,10 @@
     <div class="row">
         <div class="col-lg-9 container">
             <div class="row container--blog-meta">
-                <div class="col text-left g-font-size-12 g-mt-15 g-mb-10 icon-calander">
+                <div class="col text-left g-font-size-12 g-mt-15 g-mb-10 col-3 col-md-2">
                 {{ page.date | date_to_string }}
                 </div>  
-                <div class="col text-right g-mt-10">
+                <div class="col text-right g-mt-10 col-md-10">
                     {% include tags.html tags=page.tags %}
                 </div>
             </div>

--- a/src/_includes/publication.html
+++ b/src/_includes/publication.html
@@ -31,10 +31,10 @@
     <div class="row">
         <div class="col-lg-9 container">
             <div class="row container--blog-meta">
-                <div class="col text-left g-font-size-12 g-mt-15 g-mb-10 col-3 col-md-2">
+                <div class="col text-left text-md-left g-mt-15 g-mb-10 col-12 col-md-2 g-font-size-12">
                 {{ page.date | date_to_string }}
                 </div>  
-                <div class="col text-right g-mt-10 col-md-10">
+                <div class="col text-left text-md-right g-mt-10 col-md-10">
                     {% include tags.html tags=page.tags %}
                 </div>
             </div>

--- a/src/_includes/publication.html
+++ b/src/_includes/publication.html
@@ -5,31 +5,44 @@
 {% else %}
     {% assign pageImgUrl = site.default_post_image | prepend: site.baseurl %}
 {% endif %}
-<section class="g-bg-cover g-bg-size-cover g-bg-white-gradient-opacity-v1--after"
+<section class="g-bg-cover g-bg-size-cover g-bg-cover--text-overlay g-pb-30"
          data-bg-img-src="{{ pageImgUrl }}"
          style="background-image: url(&quot;{{ pageImgUrl }}&quot;);">
-    <div class="container text-center g-pos-rel g-z-index-1 g-pb-50">
-        <div class="row d-flex justify-content-center align-content-end flex-wrap g-min-height-300">
+    <div class="container text-center g-pos-rel g-z-index-1 g-pt-100 g-pb-100">
+        <div class="row d-flex justify-content-center align-content-end flex-wrap">
             <div class="col-lg-7 mt-auto">
-                <div class="mb-5">
-                    <h1 class="g-color-white g-font-weight-600 g-mb-30">{{ page.title }}</h1>
-                    <p class="lead g-color-white-opacity-0_6">{{ page.abstract }}</p>
-                    {% include tags.html tags=page.tags %}
-                    <p class="g-color-white-opacity-0_7 g-font-weight-300 g-font-size-12">{{ page.date | date_to_string }}</p>
+                <div class="mb-5 mt-5">
+                    <h1 class="g-color-white g-font-weight-600 g-mb-10">{{ page.title }}</h1>
+                    <p class="lead text-white g-font-weight-600">{{ page.abstract }}</p>
                 </div>
             </div>
         </div>
         {% if page.image.attribution.href %}
         <a href="{{ page.image.attribution.href }}" target="_blank">
         {% endif %}
-            <span class="g-color-white-opacity-0_5 g-font-size-10 pull-right">{{ page.image.attribution.text }}</span>
+            <span class="g-text-800 g-font-size-10 text-white">{{ page.image.attribution.text }}</span>
         {% if page.image.attribution.href %}
         </a>
         {% endif %}
     </div>
 </section>
 
-<section class="container">
+<section class="container g-mt-20">
+    <div class="row">
+        <div class="col-lg-9 container">
+            <div class="row container--blog-meta">
+                <div class="col text-left g-font-size-12 g-mt-15 g-mb-10 icon-calander">
+                {{ page.date | date_to_string }}
+                </div>  
+                <div class="col text-right g-mt-10">
+                    {% include tags.html tags=page.tags %}
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="container g-mt-20">
     <div class="row">
         <div class="col-lg-9 container">
             <div class="row">
@@ -85,7 +98,7 @@
                                 <i class="fa fa-reddit u-icon__elem-hover"></i>
                             </a>
                         </li>
-                    </ul>
+                    </ul>                    
                 </div>
             </div>
         </div>
@@ -139,7 +152,6 @@
         </div>
     </div>
 </section>
-
 
 {% include related_publications.html %}
 

--- a/src/assets/custom/css/custom-layout-2.scss
+++ b/src/assets/custom/css/custom-layout-2.scss
@@ -118,6 +118,29 @@ html {
 /* Blog page
    -------------------------------------- */
 
+.icon-calander {
+  content: '';
+  background: url('{{ site.baseurl }}/assets/custom/img/icon-calander.svg');
+  background-size: auto 85%;
+  background-position: left top;
+  background-repeat: no-repeat;
+  padding-left: 27px;
+  margin-left: 15px;
+}
+
+.container--blog-meta {
+  background-color:#FFFFFF;
+  box-shadow: 0 2px 6px 0 rgba(0,0,0,0.09);
+  border-radius: 3px;
+  margin-bottom: 20px;
+  margin-top: -45px;
+
+  .row {
+    padding: 0px;
+    background-color: red;
+  }
+}
+
 .blog {
   &-thumb {
     /* 0 0 1 0 */
@@ -205,6 +228,10 @@ html {
   width: 100%;
 }
 
+.media .u-icon-v2 {
+  border: none;
+}
+
 /* Team */
 
 .img-hover-v1 span {
@@ -218,6 +245,19 @@ html {
   margin-left: auto;
   margin-right: auto;
   width: 450px;
+}
+
+.g-bg-cover--text-overlay {
+  position: relative;
+  background-position: center;
+}
+
+.g-bg-cover--text-overlay::after {
+  content: '';
+  background-color: rgba(0, 0, 0, 0.5);
+  position: absolute;
+  width: 100%;
+  height: 100%;
 }
 
 /* Services page

--- a/src/assets/custom/img/icon-calander.svg
+++ b/src/assets/custom/img/icon-calander.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.1.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#999999;}
+</style>
+<path class="st0" d="M453.3,42.7h-48V16c0-8.8-7.2-16-16-16s-16,7.2-16,16v26.7H138.7V16c0-8.8-7.2-16-16-16s-16,7.2-16,16v26.7h-48
+	C26.3,42.7,0,69,0,101.3v352C0,485.7,26.3,512,58.7,512h394.7c32.4,0,58.7-26.3,58.7-58.7v-352C512,69,485.7,42.7,453.3,42.7z
+	 M58.7,74.7h48V112c0,8.8,7.2,16,16,16s16-7.2,16-16V74.7h234.7V112c0,8.8,7.2,16,16,16s16-7.2,16-16V74.7h48
+	c14.7,0,26.7,12,26.7,26.7v69.3H32v-69.3C32,86.6,44,74.7,58.7,74.7z M453.3,480H58.7C44,480,32,468,32,453.3V202.7h448v250.7
+	C480,468,468,480,453.3,480z"/>
+</svg>


### PR DESCRIPTION
- Separate date and meta from title/lead and house in separate container
- Add calendar icon to date
- Add overlay to the banner to increase text legibility of H1 / Lead
- Remove min-height and replace with a more flexible padding solution