### PR TITLE
Soft mod/pin articles

### DIFF
--- a/src/_includes/curated_publications.html
+++ b/src/_includes/curated_publications.html
@@ -6,7 +6,7 @@
 
   <div class="curated-publications__cards cards-layout">
     <div class="cards-layout__inner">
-      {% assign posts = site.posts | where: 'tags', include.tag %}
+      {% assign posts = site.posts | where: 'pinned_locations', include.pinned_location %}
       {% for post in posts limit: 5 %}
         {% if site.lang == "es" %}
           {% assign article_title = post.title-es %}

--- a/src/_includes/soft_mod_curated_publications.html
+++ b/src/_includes/soft_mod_curated_publications.html
@@ -1,3 +1,3 @@
 {% assign translations = site.translations[site.lang].curated-publications.softmod %}
 
-{% include curated_publications.html tag="software modernisation" title=translations.intro-title description=translations.intro-description class='soft-mod__curated-publications' %}
+{% include curated_publications.html pinned_location="soft-mod" title=translations.intro-title description=translations.intro-description class='soft-mod__curated-publications' %}

--- a/src/_posts/2015-05-09-does-tdd-lead-to-good-design.md
+++ b/src/_posts/2015-05-09-does-tdd-lead-to-good-design.md
@@ -15,6 +15,8 @@ tags:
 - TDD
 - design
 - software modernisation
+pinned_locations: 
+    - soft-mod
 ---
 
 Recently I tweeted that [TDD can’t lead to a good design if we don’t know what good design looks like](https://twitter.com/sandromancuso/status/588503877235781632). I was also saying that we probably should teach design before TDD (or at least, at the same time). This tweet led to a discussions with [J.B. Rainsberger](https://twitter.com/jbrains), [Ron Jeffries](https://twitter.com/RonJeffries), and a few others. J.B. and I ended up having a live [discussion on Hangout on Air](https://www.youtube.com/watch?v=ty3p5VDcoOI) later on. 

--- a/src/_posts/2015-08-05-becoming-evergreen.md
+++ b/src/_posts/2015-08-05-becoming-evergreen.md
@@ -14,6 +14,8 @@ image:
         href: https://flic.kr/p/dtRXDQ
 tags:
 - software modernisation
+pinned_locations: 
+    - soft-mod
 ---
 
 > “It is only when the cold season comes that we know the Pine and Cypress to be evergreens.” - *Chinese Proverb*

--- a/src/_posts/2016-07-25-thoughts-on-coupling-in-software-design.md
+++ b/src/_posts/2016-07-25-thoughts-on-coupling-in-software-design.md
@@ -17,6 +17,8 @@ tags:
 - software modernisation
 categories:
 - software-creation
+pinned_locations: 
+    - soft-mod
 ---
 
 Coupling is a software metric that describes how closely connected two routines or modules are. It is a measure of quality. The concept was introduced by Larry Constantine in the 1960s and was formulized in a 1974 article for the IBM Systems Journal, Structured Design, and in the 1979 [book](http://www.win.tue.nl/~wstomv/quotes/structured-design.html) by the same name.

--- a/src/_posts/2020-05-05-what-is-software-modernisation.md
+++ b/src/_posts/2020-05-05-what-is-software-modernisation.md
@@ -13,8 +13,8 @@ image:
     src: /assets/custom/img/blog/2020-05-05-what-is-software-modernisation/what-is-soft-mod.jpg
 tags:
     - software modernisation
-
-abstract: 
+pinned_locations: 
+    - soft-mod
 ---
 
 The goal of software is to provide value to the business. Businesses evolve and their software must evolve with it. If the alignment between software and business is frictionless then it is not merely a passive part of the organisation but an engine for innovation to allow the business to march ahead of the competition.

--- a/src/_posts/2020-05-12-5-signs-that-its-time-to-launch-a-modernisation-strategy.md
+++ b/src/_posts/2020-05-12-5-signs-that-its-time-to-launch-a-modernisation-strategy.md
@@ -14,6 +14,8 @@ image:
 tags:
     - software modernisation
     - legacy-code
+pinned_locations: 
+    - soft-mod
 ---
 
 All too often business change becomes impossible. The systems that are supposed to make your life easier don’t. In fact, you feel as if you’re putting out fires most of the time instead of focusing on the task at hand. If the following pain points are all too familiar, it’s time your organisation implements a modernisation strategy.


### PR DESCRIPTION
Updated the way that the curated publications block on the software modernisation page is populated. The change swaps out looking for content with the 'software-modernisation' tag to use a pinned_locations list added to a post.

Articles with a pinned_locations list item of 'soft-mod' articles are shown on the software modernisation curated publications block and will remain in that block until the 'soft-mod' list item is removed from the post front matter section.