### PR TITLE
Hotfix: "View all publications" button

### DIFF
--- a/src/_includes/soft_mod_curated_publications.html
+++ b/src/_includes/soft_mod_curated_publications.html
@@ -1,3 +1,3 @@
 {% assign translations = site.translations[site.lang].curated-publications.softmod %}
 
-{% include curated_publications.html pinned_location="soft-mod" title=translations.intro-title description=translations.intro-description class='soft-mod__curated-publications' %}
+{% include curated_publications.html tag="software modernisation" pinned_location="soft-mod" title=translations.intro-title description=translations.intro-description class='soft-mod__curated-publications' %}


### PR DESCRIPTION
Restore the software modernisation tag, to allow the "View all publications" button to keep working