### PR TITLE
Add drop shadow to Hero Teaser

### DIFF
--- a/src/assets/custom/css/_sass/_card.scss
+++ b/src/assets/custom/css/_sass/_card.scss
@@ -1,7 +1,11 @@
+@mixin style-card-box-shadow {
+  box-shadow: rgba(0, 0, 0, 0.16) 0 0 8px;
+}
+
 .card {
+  @include style-card-box-shadow;
   background-color: white;
   border-radius: 3px;
-  box-shadow: rgba(0, 0, 0, 0.16) 0 0 8px;
   overflow: hidden;
 }
 

--- a/src/assets/custom/css/_sass/_hero-teaser.scss
+++ b/src/assets/custom/css/_sass/_hero-teaser.scss
@@ -134,6 +134,7 @@
     padding-right: $lateral-space--medium;
   }
   @include large-and-extra-large {
+    box-shadow: rgba(0,0,0,0.16) 0 0 8px;
     padding-left: $lateral-space--large;
     padding-right: $lateral-space--large;
   }

--- a/src/assets/custom/css/_sass/_hero-teaser.scss
+++ b/src/assets/custom/css/_sass/_hero-teaser.scss
@@ -134,7 +134,7 @@
     padding-right: $lateral-space--medium;
   }
   @include large-and-extra-large {
-    box-shadow: rgba(0,0,0,0.16) 0 0 8px;
+    @include style-card-box-shadow;
     padding-left: $lateral-space--large;
     padding-right: $lateral-space--large;
   }


### PR DESCRIPTION
**What**
This PR adds a drop shadow to the white card sections of the Hero Teaser component upwards of large screens. 

This PR also unifies the shadow that's used within the cards holding the Curated Publications and the content of the Hero Teaser as mentioned above. 

**Why**
This is to improve contrast between the white of the card and the background it sits on. On less quality monitors and displays the contrast between these two elements may not be noticeable.

<img width="1157" alt="Screenshot 2020-05-13 at 17 59 46" src="https://user-images.githubusercontent.com/27159748/81842221-9007d000-9543-11ea-9ba0-184987a6f887.png">
 
