### PR TITLE
Remove unecessary target blank

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,10 +174,16 @@ tags:
 
 Links can be added to a post in a couple of ways. The preference is to make sure that `target="_blank"` is used so that any links open in a new browser tab and do not take the user away from the blog post or the website.
 
-To use `target="_blank"` the only currently supported by our Jekyll version is to include links as HTML in the markdown. So for example -
+Javascript on the website will add target blank to any external links when the DOM loads, so you can use markdown style links like this:
 
+```markdown
+[Link Example](https://www.example.com)
 ```
-<a href="https://www.example.com" target="_blank">Link Example</a>
+
+To explicitly set the target of a link you can use HTML in the markdown like this:
+
+```html
+<a href="https://www.example.com" target="custom">Link Example</a>
 ```
 
 ### Adding a video to the publications

--- a/src/_includes/hero_teaser.html
+++ b/src/_includes/hero_teaser.html
@@ -4,6 +4,6 @@
     <h2 class="hero-teaser__content-type">{{ include.content_type }}</h2>
     <h3 class="hero-teaser__title">{{ include.title }}</h3>
     <p class="hero-teaser__description">{{ include.description }}</p>
-    {% include cta_primary_link.html color='coral' href=include.cta-href target="_blank" text=include.cta %}
+    {% include cta_primary_link.html color='coral' href=include.cta-href text=include.cta %}
   </div>
 </section>


### PR DESCRIPTION
These changes fix an issue noticed by @mattgraygithub where the **Hero Teaser** of the **Curated Publications** always opens in a new tab.

I've also updated the README since the recent Javascript changes that add target _blank to all external links.