### PR TITLE
Apply Section Intros UI in place of bespoke HTML and CSS

### DIFF
--- a/src/_includes/curated_publications.html
+++ b/src/_includes/curated_publications.html
@@ -1,8 +1,5 @@
 <section class="curated-publications {{include.class}}">
-  <header class="section-intro">
-    <h2 class="section-intro__title">{{include.title}}</h2>
-    <p class="section-intro__description">{{include.description}}</p>
-  </header>
+  {% include section_intro.html description=include.description title=include.title %}
 
   {% assign posts = site.posts | where: 'pinned_locations', include.pinned_location %}
   {% for post in posts limit: 1 %}

--- a/src/_includes/section_intro.html
+++ b/src/_includes/section_intro.html
@@ -1,0 +1,4 @@
+<header class="section-intro">
+  <h2 class="section-intro__title">{{include.title}}</h2>
+  <p class="section-intro__description">{{include.description}}</p>
+</header>

--- a/src/assets/custom/css/_sass/_soft-mod-misc.scss
+++ b/src/assets/custom/css/_sass/_soft-mod-misc.scss
@@ -77,10 +77,6 @@
   .g-pb-100--desk {
     padding-bottom: 100px !important;
   }
-
-  .g-pb-200--desk {
-    padding-bottom: 200px !important;
-  }
 }
 
 /********************************
@@ -106,12 +102,6 @@
 .bg-slate--pattern {
   background-image: url("#{$site-base-url}/assets/custom/img/softmod/bg-slate-pattern-2.jpg");
   background-size: 100%;
-  background-repeat: no-repeat;
-}
-
-.bg-testimonials {
-  background: url("#{$site-base-url}/assets/custom/img/softmod/bg-testimonials.png");
-  background-size: cover;
   background-repeat: no-repeat;
 }
 
@@ -162,13 +152,6 @@
     background-position: center bottom 50px;
     background-repeat: no-repeat;
     background-size: 40% auto;
-  }
-
-  .bg-testimonials {
-    background: url("#{$site-base-url}/assets/custom/img/softmod/bg-testimonials.jpg");
-    background-size: 110% auto;
-    background-position-y: 360px;
-    background-repeat: no-repeat;
   }
 }
 

--- a/src/assets/custom/css/_sass/_soft-mod.scss
+++ b/src/assets/custom/css/_sass/_soft-mod.scss
@@ -6,7 +6,7 @@
 }
 
 .soft-mod__testimonials {
-  background: url("#{$site-base-url}/assets/custom/img/softmod/bg-testimonials.png");
+  background: url("#{$site-base-url}/assets/custom/img/softmod/bg-testimonials.jpg");
   background-repeat: no-repeat;
   padding-top: 50px;
 

--- a/src/assets/custom/css/_sass/_soft-mod.scss
+++ b/src/assets/custom/css/_sass/_soft-mod.scss
@@ -12,10 +12,8 @@
   padding-top: 50px;
 
   @media (min-width: 800px) {
-    background: url("#{$site-base-url}/assets/custom/img/softmod/bg-testimonials.jpg");
     background-size: 110% auto;
     background-position-y: 360px;
-    background-repeat: no-repeat;
   }
   @media (min-width: 992px) {
     padding-bottom: 200px !important;

--- a/src/assets/custom/css/_sass/_soft-mod.scss
+++ b/src/assets/custom/css/_sass/_soft-mod.scss
@@ -5,6 +5,10 @@
   }
 }
 
+.soft-mod__testimonials {
+  padding-top: 50px;
+}
+
 .soft-mod__publications {
   background: $sheen;
 

--- a/src/assets/custom/css/_sass/_soft-mod.scss
+++ b/src/assets/custom/css/_sass/_soft-mod.scss
@@ -6,7 +6,20 @@
 }
 
 .soft-mod__testimonials {
+  background: url("#{$site-base-url}/assets/custom/img/softmod/bg-testimonials.png");
+  background-size: cover;
+  background-repeat: no-repeat;
   padding-top: 50px;
+
+  @media (min-width: 800px) {
+    background: url("#{$site-base-url}/assets/custom/img/softmod/bg-testimonials.jpg");
+    background-size: 110% auto;
+    background-position-y: 360px;
+    background-repeat: no-repeat;
+  }
+  @media (min-width: 992px) {
+    padding-bottom: 200px !important;
+  }
 }
 
 .soft-mod__publications {

--- a/src/assets/custom/css/_sass/_soft-mod.scss
+++ b/src/assets/custom/css/_sass/_soft-mod.scss
@@ -7,16 +7,18 @@
 
 .soft-mod__testimonials {
   background: url("#{$site-base-url}/assets/custom/img/softmod/bg-testimonials.png");
-  background-size: cover;
   background-repeat: no-repeat;
   padding-top: 50px;
 
-  @media (min-width: 800px) {
+  @include small {
+    background-size: cover;
+  }
+  @include medium-large-and-extra-large {
     background-size: 110% auto;
     background-position-y: 360px;
   }
-  @media (min-width: 992px) {
-    padding-bottom: 200px !important;
+  @include large-and-extra-large {
+    padding-bottom: 200px;
   }
 }
 

--- a/src/software-modernisation/index.html
+++ b/src/software-modernisation/index.html
@@ -290,15 +290,13 @@ metarobots: index,follow
   </div>
 </section><!-- Case Studies -->
 
-<section class="section bg-testimonials g-pb-200--desk">
-  <div class="container-slim center">
-    <h4 class="text-center h2 text-700">{% t software-modernisation.testimonials-heading %}</h4>
-    <p class="lead text-center">
-      {% t software-modernisation.testimonials-subheading %}
-    </p>
+<section class="soft-mod__testimonials bg-testimonials g-pb-200--desk">
+  {% capture title %}{% t software-modernisation.testimonials-heading %}{% endcapture %}
+  {% capture description %}{% t software-modernisation.testimonials-subheading %}{% endcapture %}
+  {% include section_intro.html description=description title=title %}
 
-    <!--  Testimonials Flexslider -->
-    <div class="flexslider g-mt-50">
+  <div class="container-slim center">
+    <div class="flexslider">
     <ul class="slides box-shadow">
       <li class="g-px-50 g-py-30 text-center">
         <p>{% t software-modernisation.testimonials-bestsecret-p1 %}</p>
@@ -320,7 +318,7 @@ metarobots: index,follow
     </ul>
     </div>
   </div>
-</section><!-- Testimonials -->
+</section>
 
 <section class="bg-slate bg-slate--pattern center">
 
@@ -332,10 +330,10 @@ metarobots: index,follow
   </div>
 
   <div id="get-in-touch" class="soft-mod__form-holder container-slim bg-white g-pt-50 g-pt-100--desk g-pb-100 text-center">
-    <h2 class="text-center h2 text-700 g-pb-15"> {% t software-modernisation.contact-heading %}</h2>
-    <p class="lead mx-width-600 g-pb-35">
-      {% t software-modernisation.contact-subheading %}
-    </p>
+    {% capture title %}{% t software-modernisation.contact-heading %}{% endcapture %}
+    {% capture description %}{% t software-modernisation.contact-subheading %}{% endcapture %}
+    {% include section_intro.html description=description title=title %}
+    
     <div class="sm-enquiry g-pt-50">
       <!-- Hubspot Form Embed - Test Software Modernisation-->
       <!--[if lte IE 8]>

--- a/src/software-modernisation/index.html
+++ b/src/software-modernisation/index.html
@@ -290,7 +290,7 @@ metarobots: index,follow
   </div>
 </section><!-- Case Studies -->
 
-<section class="soft-mod__testimonials bg-testimonials g-pb-200--desk">
+<section class="soft-mod__testimonials">
   {% capture title %}{% t software-modernisation.testimonials-heading %}{% endcapture %}
   {% capture description %}{% t software-modernisation.testimonials-subheading %}{% endcapture %}
   {% include section_intro.html description=description title=title %}


### PR DESCRIPTION
In this PR we extract the HTML for the Section Intro into it's own file and replace some existing HTML and CSS. 

There was also some quick clean up of the Testimonials element on the Soft Mod page introducing the shared breakpoints and CSS approach.