### PR TITLE
Ensure consistent vertical spacing

### DIFF
--- a/src/assets/custom/css/_sass/_soft-mod-problems.scss
+++ b/src/assets/custom/css/_sass/_soft-mod-problems.scss
@@ -12,7 +12,20 @@
     z-index: 0;
   }
 
+  @include small {
+    padding-bottom: 50px;
+    padding-top: 50px;
+  }
+
+  @include medium-and-large {
+    padding-top: 100px;
+    padding-bottom: 100px;
+  }
+
   @include extra-large {
+    padding-top: 100px;
+
+
     &:before {
       right: 100px;
     }

--- a/src/software-modernisation/index.html
+++ b/src/software-modernisation/index.html
@@ -36,7 +36,7 @@ metarobots: index,follow
   </div><!-- grid -->
 </section><!-- sm-hero -->
 
-<section id="how-we-solve-your-problems" class="section soft-mod-problems">
+<section id="how-we-solve-your-problems" class="soft-mod-problems">
   {% capture title %}{% t software-modernisation.problems-title %}{% endcapture %}
   {% capture description %}{% t software-modernisation.problems-introduction %}{% endcapture %}
   {% assign cta_href = "#get-in-touch" %}


### PR DESCRIPTION
Removes excess spacing between the 'How we solve your problems' and 'How we've helped our clients' sections.