### PR TITLE
small change to update the compass URL for the ES version.

### DIFF
--- a/src/_includes/compass_teaser.html
+++ b/src/_includes/compass_teaser.html
@@ -1,7 +1,7 @@
 <section id="compass-by-codurance" class="compass-teaser">
   <p class="compass-teaser__description">{% t software-modernisation.compassCTA-subheading %}</p>
   {% if site.lang == 'es' %}
-      {% assign href = "http://compass-es.codurance.com" %}
+      {% assign href = "http://compass.codurance.es" %}
     {% else %}
       {% assign href = "http://compass.codurance.com" %}
   {% endif %}


### PR DESCRIPTION
Request to update the compass URL for the Spanish version: 
From using `compass-es.codurance.com`
To use `compass.codurance.es`