### PR TITLE
Fix: Accessing sections of the page specified by the hash within the URL

### DIFF
--- a/src/_includes/compass_teaser.html
+++ b/src/_includes/compass_teaser.html
@@ -1,4 +1,7 @@
-<section id="compass-by-codurance" class="compass-teaser">
+<section class="compass-teaser">
+  {%- assign anchor_id = "compass-by-codurance" -%}
+  {% include page_location_anchor.html anchor_id=anchor_id %}
+
   <p class="compass-teaser__description">{% t software-modernisation.compassCTA-subheading %}</p>
   {% if site.lang == 'es' %}
       {% assign href = "http://compass-es.codurance.com" %}

--- a/src/_includes/page_location_anchor.html
+++ b/src/_includes/page_location_anchor.html
@@ -1,1 +1,1 @@
-<a id="{{ include.anchor_id }}" class="on-page-anchor {{ include.on_page_anchor_class }}"></a>
+<a id="{{ include.anchor_id }}" class="on-page-anchor {{ include.anchor_class }}"></a>

--- a/src/_includes/page_location_anchor.html
+++ b/src/_includes/page_location_anchor.html
@@ -1,0 +1,1 @@
+<a id="{{ include.anchor_id }}" class="on-page-anchor {{ include.on_page_anchor_class }}"></a>

--- a/src/_includes/soft_mod_curated_publications.html
+++ b/src/_includes/soft_mod_curated_publications.html
@@ -1,3 +1,9 @@
 {% assign translations = site.translations[site.lang].curated-publications.softmod %}
 
-{% include curated_publications.html id="publications" tag="software modernisation" pinned_location="soft-mod" title=translations.intro-title description=translations.intro-description class='soft-mod__curated-publications' %}
+<div>
+  {%- assign anchor_id = "publications" -%}
+  {% include page_location_anchor.html anchor_id=anchor_id %}
+
+  {% include curated_publications.html tag="software modernisation" pinned_location="soft-mod" title=translations.intro-title description=translations.intro-description class='soft-mod__curated-publications' %}
+</div>
+

--- a/src/_includes/soft_mod_curated_publications.html
+++ b/src/_includes/soft_mod_curated_publications.html
@@ -1,9 +1,9 @@
 {% assign translations = site.translations[site.lang].curated-publications.softmod %}
 
-<div>
+<div class="soft-mod__curated-publications">
   {%- assign anchor_id = "publications" -%}
   {% include page_location_anchor.html anchor_id=anchor_id %}
 
-  {% include curated_publications.html tag="software modernisation" pinned_location="soft-mod" title=translations.intro-title description=translations.intro-description class='soft-mod__curated-publications' %}
+  {% include curated_publications.html tag="software modernisation" pinned_location="soft-mod" title=translations.intro-title description=translations.intro-description  %}
 </div>
 

--- a/src/_includes/soft_mod_webinar_hero_teaser.html
+++ b/src/_includes/soft_mod_webinar_hero_teaser.html
@@ -5,4 +5,9 @@
 {% assign cta-href = teaser.cta-href %}
 {% assign image_position = 'left' %}
 {% capture image_src %}{{site.baseurl}}/assets/custom/img/softmod/softmod-in-distributed-worktimes-hero.jpg{% endcapture %}
-{% include hero_teaser.html class="soft-mod__webinar-teaser" content_type='Webinar' id="webinar" cta=cta cta-href=cta-href image_position=image_position image_src=image_src title=title description=description %}
+{%- assign anchor_id = "webinar" -%}
+
+<div>
+  {% include page_location_anchor.html anchor_id=anchor_id %}
+  {% include hero_teaser.html class="soft-mod__webinar-teaser" content_type='Webinar' cta=cta cta-href=cta-href image_position=image_position image_src=image_src title=title description=description %}
+</div>

--- a/src/_includes/soft_mod_webinar_hero_teaser.html
+++ b/src/_includes/soft_mod_webinar_hero_teaser.html
@@ -7,7 +7,7 @@
 {% capture image_src %}{{site.baseurl}}/assets/custom/img/softmod/softmod-in-distributed-worktimes-hero.jpg{% endcapture %}
 {%- assign anchor_id = "webinar" -%}
 
-<div>
+<div class="soft-mod__webinar-teaser">
   {% include page_location_anchor.html anchor_id=anchor_id %}
-  {% include hero_teaser.html class="soft-mod__webinar-teaser" content_type='Webinar' cta=cta cta-href=cta-href image_position=image_position image_src=image_src title=title description=description %}
+  {% include hero_teaser.html content_type='Webinar' cta=cta cta-href=cta-href image_position=image_position image_src=image_src title=title description=description %}
 </div>

--- a/src/assets/custom/css/_sass/_page-location-anchor.scss
+++ b/src/assets/custom/css/_sass/_page-location-anchor.scss
@@ -1,0 +1,4 @@
+.on-page-anchor {
+  position: relative;
+  display: block;
+}

--- a/src/assets/custom/css/_sass/_site-navbar-height.scss
+++ b/src/assets/custom/css/_sass/_site-navbar-height.scss
@@ -1,0 +1,2 @@
+$site-navbar-height-base: 74px;
+$site-navbar-height-large: 98px;

--- a/src/assets/custom/css/_sass/_soft-mod.scss
+++ b/src/assets/custom/css/_sass/_soft-mod.scss
@@ -1,3 +1,12 @@
+.on-page-anchor {
+  top: calc(-50px - #{$site-navbar-height-base});
+}
+@media (min-width: 992px) and (max-width: $largeMax) {
+  .on-page-anchor {
+    top: calc(-50px - #{$site-navbar-height-large});
+  }
+}
+
 .soft-mod__testimonials {
   background-image: url("#{$site-base-url}/assets/custom/img/softmod/bg-testimonials.jpg");
   background-repeat: no-repeat;

--- a/src/assets/custom/css/_sass/_soft-mod.scss
+++ b/src/assets/custom/css/_sass/_soft-mod.scss
@@ -47,8 +47,21 @@
 }
 
 .soft-mod__webinar-teaser {
+  @include small {
+    .on-page-anchor {
+      top: calc(0px - #{$site-navbar-height-base});
+    }
+  }
   @include medium-large-and-extra-large {
     margin-bottom: 50px;
+  }
+}
+
+.soft-mod__curated-publications {
+  @include small {
+    .on-page-anchor {
+      top: calc(0px - #{$site-navbar-height-base});
+    }
   }
 }
 
@@ -71,5 +84,16 @@
 .soft-mod__get-in-touch {
   @include medium-large-and-extra-large {
     padding-top: 50px;
+  }
+
+  @include small {
+    .on-page-anchor {
+      top: calc(0px - #{$site-navbar-height-base});
+    }
+  }
+  @media (min-width: 992px) and (max-width: $largeMax) {
+    .on-page-anchor {
+      top: calc(40px - #{$site-navbar-height-large});
+    }
   }
 }

--- a/src/assets/custom/css/main.scss
+++ b/src/assets/custom/css/main.scss
@@ -15,6 +15,7 @@ $site-base-url: "{{ site.baseurl }}";
 @import "curated-publications";
 @import "hero-teaser";
 @import "section-intro";
+@import "page-location-anchor";
 
 @import "compass-teaser";
 @import "flexslider";

--- a/src/assets/custom/css/main.scss
+++ b/src/assets/custom/css/main.scss
@@ -10,6 +10,7 @@ $site-base-url: "{{ site.baseurl }}";
 @import "backgrounds";
 @import "cta";
 @import "card";
+@import "site-navbar-height";
 
 @import "cards-layout";
 @import "curated-publications";

--- a/src/software-modernisation/index.html
+++ b/src/software-modernisation/index.html
@@ -36,7 +36,11 @@ metarobots: index,follow
   </div><!-- grid -->
 </section><!-- sm-hero -->
 
-<section id="how-we-solve-your-problems" class="soft-mod-problems">
+
+<section class="soft-mod-problems">
+  {%- assign anchor_id = "how-we-solve-your-problems" -%}
+  {% include page_location_anchor.html anchor_id=anchor_id %}
+
   {% capture title %}{% t software-modernisation.problems-title %}{% endcapture %}
   {% capture description %}{% t software-modernisation.problems-introduction %}{% endcapture %}
   {% assign cta_href = "#get-in-touch" %}
@@ -203,7 +207,9 @@ metarobots: index,follow
   </div>
 </section>
 
-<section id="how-we-help-our-clients" class="soft-mod__our-clients">
+<section class="soft-mod__our-clients">
+  {%- assign anchor_id = "how-we-help-our-clients" -%}
+  {% include page_location_anchor.html anchor_id=anchor_id %}
   <div class="container">
 
     <h2 class="text-center--bp768 text-700 text-white">{% t software-modernisation.clients-title %}</h2>
@@ -278,7 +284,10 @@ metarobots: index,follow
   </div>
 </section><!-- Case Studies -->
 
-<section id="testimonials" class="soft-mod__testimonials">
+<section class="soft-mod__testimonials">
+  {%- assign anchor_id = "testimonials" -%}
+  {% include page_location_anchor.html anchor_id=anchor_id %}
+
   {% capture title %}{% t software-modernisation.testimonials-heading %}{% endcapture %}
   {% capture description %}{% t software-modernisation.testimonials-subheading %}{% endcapture %}
   {% include section_intro.html class="soft-mod__testimonials-intro" description=description title=title %}
@@ -314,7 +323,10 @@ metarobots: index,follow
   {% include soft_mod_curated_publications.html %}
 </div>
 
-<section id="get-in-touch" class="soft-mod__get-in-touch">
+<section class="soft-mod__get-in-touch">
+  {%- assign anchor_id = "get-in-touch" -%}
+  {% include page_location_anchor.html anchor_id=anchor_id %}
+
   <div class="container-slim bg-white g-pt-50 g-pt-100--desk g-pb-100 text-center">
     {% capture title %}{% t software-modernisation.contact-heading %}{% endcapture %}
     {% capture description %}{% t software-modernisation.contact-subheading %}{% endcapture %}


### PR DESCRIPTION
This PR adds a new component, the Page Location Anchor. 

This is used to add an on-page anchor to specific sections that we would like the browser to take the user to, or if we would like to create links directly to the specific section.

It takes the site's navigation bar into account so that it will no longer overlap the content we wish to be displayed. 