### PR TITLE
Add google tag manager

### DIFF
--- a/src/_includes/foot.html
+++ b/src/_includes/foot.html
@@ -108,6 +108,18 @@
 
   <script src="{{ '/assets/custom/js/cookie-message.js' | prepend: site.baseurl }}"></script>
 
+  <script>
+  if(codurance.cookieMessage.hasConsent()) {
+    dataLayer.push({'anonymizeIp': 'false'});
+  } else {
+    codurance.cookieMessage.onConsent(function(){
+      dataLayer.push({'anonymizeIp': 'false'});
+    });
+  }
+</script>
+
+
+
   <!-- Start of Google analytics configuration
   <script>
     if(codurance.cookieMessage.hasConsent()) {

--- a/src/_includes/foot.html
+++ b/src/_includes/foot.html
@@ -111,7 +111,7 @@
   <!-- Start of Google analytics configuration
   <script>
     if(codurance.cookieMessage.hasConsent()) {
-      ga('set', 'anonymizeIp', undefined);
+      ga('set', 'anonymizeIp', undefined) ;
     } else {
       codurance.cookieMessage.onConsent(function(){
         ga('set', 'anonymizeIp', undefined);

--- a/src/_includes/foot.html
+++ b/src/_includes/foot.html
@@ -108,7 +108,7 @@
 
   <script src="{{ '/assets/custom/js/cookie-message.js' | prepend: site.baseurl }}"></script>
 
-  <script>
+  <!-- <script>
   if(codurance.cookieMessage.hasConsent()) {
     dataLayer.push({'anonymizeIp': 'false'});
   } else {
@@ -116,7 +116,7 @@
       dataLayer.push({'anonymizeIp': 'false'});
     });
   }
-</script>
+</script> -->
 
 
 

--- a/src/_includes/foot.html
+++ b/src/_includes/foot.html
@@ -110,37 +110,13 @@
 
   <script>
   if(codurance.cookieMessage.hasConsent()) {
-    dataLayer.push({'anonymizeIp': 'false'});
+      dataLayer.push({'anonymizeIp': 'false'});
   } else {
     codurance.cookieMessage.onConsent(function(){
       dataLayer.push({'anonymizeIp': 'false'});
     });
   }
 </script>
-
-
-
-  <!-- Start of Google analytics configuration
-  <script>
-    if(codurance.cookieMessage.hasConsent()) {
-      ga('set', 'anonymizeIp', undefined) ;
-    } else {
-      codurance.cookieMessage.onConsent(function(){
-        ga('set', 'anonymizeIp', undefined);
-      });
-    }
-    ga('send', 'pageview');
-
-    $(window).on('resize', function () {
-      setTimeout(function () {
-        var gaEvents = window.googleAnalyticsEvents;
-        gaEvents.functions.forEach(function(fireEvent){
-          fireEvent(gaEvents.environment);
-        });
-      }, 200);
-    });
-  </script>
- End of Google analytics configuration -->
 
   <!-- Start of HubSpot Embed Code -->
   <script>

--- a/src/_includes/foot.html
+++ b/src/_includes/foot.html
@@ -108,7 +108,7 @@
 
   <script src="{{ '/assets/custom/js/cookie-message.js' | prepend: site.baseurl }}"></script>
 
-  <!-- Start of Google analytics configuration -->
+  <!-- Start of Google analytics configuration
   <script>
     if(codurance.cookieMessage.hasConsent()) {
       ga('set', 'anonymizeIp', undefined);
@@ -128,7 +128,7 @@
       }, 200);
     });
   </script>
-  <!-- End of Google analytics configuration -->
+ End of Google analytics configuration -->
 
   <!-- Start of HubSpot Embed Code -->
   <script>

--- a/src/_includes/foot.html
+++ b/src/_includes/foot.html
@@ -108,16 +108,6 @@
 
   <script src="{{ '/assets/custom/js/cookie-message.js' | prepend: site.baseurl }}"></script>
 
-  <!-- <script>
-  if(codurance.cookieMessage.hasConsent()) {
-      dataLayer.push({'anonymizeIp': 'false'});
-  } else {
-    codurance.cookieMessage.onConsent(function(){
-      dataLayer.push({'anonymizeIp': 'false'});
-    });
-  }
-</script> -->
-
   <!-- Start of HubSpot Embed Code -->
   <script>
       var loadHubsopot = function() {

--- a/src/_includes/google_tag_manager.html
+++ b/src/_includes/google_tag_manager.html
@@ -1,4 +1,6 @@
 <!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WH8CK39"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<noscript>
+    <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WH8CK39"
+height="0" width="0" style="display:none;visibility:hidden"></iframe>
+</noscript>
 <!-- End Google Tag Manager (noscript) -->

--- a/src/_includes/google_tag_manager.html
+++ b/src/_includes/google_tag_manager.html
@@ -1,6 +1,0 @@
-<!-- Google Tag Manager (noscript) -->
-<noscript>
-    <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WH8CK39"
-height="0" width="0" style="display:none;visibility:hidden"></iframe>
-</noscript>
-<!-- End Google Tag Manager (noscript) -->

--- a/src/_includes/google_tag_manager.html
+++ b/src/_includes/google_tag_manager.html
@@ -1,0 +1,4 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WH8CK39"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->

--- a/src/_includes/google_tag_manager_noscript.html
+++ b/src/_includes/google_tag_manager_noscript.html
@@ -1,0 +1,4 @@
+<noscript>
+    <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WH8CK39"
+height="0" width="0" style="display:none;visibility:hidden"></iframe>
+</noscript>

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -14,6 +14,19 @@
  <meta name="robots" content="{{ page.metarobots }}" />
 {% endif %}
 
+<!-- Google Tag Manager -->
+<script>
+  var cookie = document.cookie;
+  if (cookie.includes("has-cookie-consent=yes")){
+    console.log("I Have a Cookie");
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-WH8CK39');
+  }
+</script>
+<!-- End Google Tag Manager -->
 
 <!-- Open Graph Protocol  -->
 <meta prefix="og: http://ogp.me/ns#" property="og:title" content="{{social_title}}" />
@@ -114,20 +127,6 @@
 {% if page.canonical %}
 <link rel="canonical" href="{{ page.canonical.href }}" />
 {% endif %}
-
-<script>
-    dataLayer = [{
-      'anonymizeIp': 'true'
-    }];
-</script>
-
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-WH8CK39');</script>
-<!-- End Google Tag Manager -->
 
 <script type="text/javascript" src="https://secure.leadforensics.com/js/113763.js" ></script>
 <noscript><img alt="" src="https://secure.leadforensics.com/113763.png?trk_user=113763&trk_tit=jsdisabled&trk_ref=jsdisabled&trk_loc=jsdisabled" height="0px" width="0px" style="display:none;" /></noscript>

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -115,12 +115,22 @@
 <link rel="canonical" href="{{ page.canonical.href }}" />
 {% endif %}
 
+<script>
+    if (codurance.cookieMessage.hasConsent()) {
+        dataLayer = [{
+            'anonymizeIp': 'false'
+        }];
+        return;
+    }
+    dataLayer = [{'anonymizeIp': 'true'}];
+</script> 
+
 <!-- Google Tag Manager -->
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-WH8CK39');</script>
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-WH8CK39');</script>
 <!-- End Google Tag Manager -->
 
 <!--

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -116,15 +116,10 @@
 {% endif %}
 
 <script>
-    if (codurance.cookieMessage.hasConsent()) {
-        dataLayer = [{
-            'anonymizeIp': 'false'
-        }];
-        return;
-    }
-    dataLayer = [{'anonymizeIp': 'true'}];
-</script> 
-
+    dataLayer = [{
+      'anonymizeIp': 'true'
+    }];
+</script>
 <!-- Google Tag Manager -->
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -115,6 +115,15 @@
 <link rel="canonical" href="{{ page.canonical.href }}" />
 {% endif %}
 
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-WH8CK39');</script>
+<!-- End Google Tag Manager -->
+
+<!--
 <script>
     window.codurance = window.codurance || {};
 
@@ -129,7 +138,7 @@
     window.googleAnalyticsEvents = { environment: {ga:ga}, functions: []};
     // fire all events at onload/resize - see _includes/foot.html
 </script>
-
+-->
 <script type="text/javascript" src="https://secure.leadforensics.com/js/113763.js" ></script>
 <noscript><img alt="" src="https://secure.leadforensics.com/113763.png?trk_user=113763&trk_tit=jsdisabled&trk_ref=jsdisabled&trk_loc=jsdisabled" height="0px" width="0px" style="display:none;" /></noscript>
 

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -120,6 +120,7 @@
       'anonymizeIp': 'true'
     }];
 </script>
+
 <!-- Google Tag Manager -->
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -128,22 +129,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 })(window,document,'script','dataLayer','GTM-WH8CK39');</script>
 <!-- End Google Tag Manager -->
 
-<!--
-<script>
-    window.codurance = window.codurance || {};
-
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-    ga('create', '{% t analytics.google-id %}', 'auto');
-    ga('set', 'forceSSL', true);
-
-    window.googleAnalyticsEvents = { environment: {ga:ga}, functions: []};
-    // fire all events at onload/resize - see _includes/foot.html
-</script>
--->
 <script type="text/javascript" src="https://secure.leadforensics.com/js/113763.js" ></script>
 <noscript><img alt="" src="https://secure.leadforensics.com/113763.png?trk_user=113763&trk_tit=jsdisabled&trk_ref=jsdisabled&trk_loc=jsdisabled" height="0px" width="0px" style="display:none;" /></noscript>
 

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -14,7 +14,6 @@
  <meta name="robots" content="{{ page.metarobots }}" />
 {% endif %}
 
-<!-- Google Tag Manager -->
 <script>
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -22,7 +21,6 @@
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-WH8CK39');
 </script>
-<!-- End Google Tag Manager -->
 
 <!-- Open Graph Protocol  -->
 <meta prefix="og: http://ogp.me/ns#" property="og:title" content="{{social_title}}" />

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -16,15 +16,11 @@
 
 <!-- Google Tag Manager -->
 <script>
-  var cookie = document.cookie;
-  if (cookie.includes("has-cookie-consent=yes")){
-    console.log("I Have a Cookie");
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-WH8CK39');
-  }
 </script>
 <!-- End Google Tag Manager -->
 

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -10,7 +10,7 @@ layout: compress
 </head>
 
 <body>
-{% include google_tag_manager.html %}
+{% include google_tag_manager_noscript.html %}
 
 <div class="wrapper">
 <!--=== Header ===-->

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -10,6 +10,7 @@ layout: compress
 </head>
 
 <body>
+{% include google_tag_manager.html %}
 
 <div class="wrapper">
 <!--=== Header ===-->

--- a/src/assets/custom/js/cookie-message.js
+++ b/src/assets/custom/js/cookie-message.js
@@ -110,7 +110,6 @@ window.codurance.cookieMessage = (function() {
     }
 
     function init () {
-        
         if (hasConsent()) {
             showConsentDependentIframes();
             return;

--- a/src/assets/custom/js/cookie-message.js
+++ b/src/assets/custom/js/cookie-message.js
@@ -110,6 +110,7 @@ window.codurance.cookieMessage = (function() {
     }
 
     function init () {
+        
         if (hasConsent()) {
             showConsentDependentIframes();
             return;

--- a/src/assets/custom/js/cookie-message.js
+++ b/src/assets/custom/js/cookie-message.js
@@ -129,7 +129,6 @@ window.codurance.cookieMessage = (function() {
     }
 
     init();
-
     return {
         hasConsent: hasConsent,
         onConsent: onConsent


### PR DESCRIPTION
This PR: 

- Adds google tag manager to handle the interaction with our google analytics account for the website.
- Separates your localhost and preview from the live analytics with localhost and preview traffic directed to a separate test property in google analytics UI. (`Codurance Website Test`)
- Previously the cookie consent was un-anonymizing the user IP in google analytics, we removed this behavior and kept the page view as a "functional cookie", on consent we will allow the tracking of clicks and navigation through the page.

This will help us control the tracking of users (who have given consent) in relation to capturing data on events (button clicks, etc..), page views will still be sent to google analytics as standard.

However, the use of cookies on all our websites need to be reviewed to ensure we comply with all the relevant regulations (GDPR and cookie law). 