### PR TITLE
Move anchor above get in touch section

### DIFF
--- a/src/_includes/get_in_touch.html
+++ b/src/_includes/get_in_touch.html
@@ -1,6 +1,5 @@
+{% include page_location_anchor.html anchor_id="get-in-touch" %}
 <section class="get-in-touch">
-  {% include page_location_anchor.html anchor_id="get-in-touch" %}
-
   <div class="get-in-touch__inner">
     {% include section_intro.html description=include.description title=include.title %}
 


### PR DESCRIPTION
This corrects the position when people scroll to #get-in-touch anchors (e.g. https://codurance.com/contact-us/#get-in-touch)

@jpwenzelc @mattgraygithub @Dan-Bird this was the commit we missed out of #1786 
