### PR TITLE
Update hash links for Soft-Mod

### DIFF
--- a/src/_i18n/en.yml
+++ b/src/_i18n/en.yml
@@ -803,6 +803,15 @@ software-modernisation:
       cta: Watch Webinar
       cta-href: https://info.codurance.com/en/software-modernisation-in-distributed-work-times
 
+  page-sections:
+    how-we-solve-your-problems: how-we-solve-your-problems
+    how-we-help-our-clients: how-we-help-our-clients
+    testimonials: testimonials
+    compass: compass-by-codurance
+    webinar: webinar
+    publications: publications
+    get-in-touch: get-in-touch
+
 curated-publications:
   softmod:
     intro-title: Software Modernisation publications

--- a/src/_i18n/es.yml
+++ b/src/_i18n/es.yml
@@ -812,6 +812,15 @@ software-modernisation:
       cta: Ver webinar
       cta-href: https://info.codurance.com/es/software-modernisation-en-tiempos-de-trabajo-distribu%C3%ADdo
 
+  page-sections:
+    how-we-solve-your-problems: como-podemos-ayudarte
+    how-we-help-our-clients: como-adyudamos-nuestros-clientes
+    testimonials: opinion-de-nuestros-clientes
+    compass: compass-by-codurance
+    webinar: webinar-software-modernisation-trabajo-distribuido
+    publications: publicaciones
+    get-in-touch: contacto
+
 curated-publications:
   softmod:
     intro-title: Sobre Software Modernisation

--- a/src/_includes/compass_teaser.html
+++ b/src/_includes/compass_teaser.html
@@ -1,5 +1,5 @@
 <section class="compass-teaser">
-  {%- assign anchor_id = "compass-by-codurance" -%}
+  {%- assign anchor_id = {site.translations[site.lang].software-modernisation.page-sections.compass} -%}
   {% include page_location_anchor.html anchor_id=anchor_id %}
 
   <p class="compass-teaser__description">{% t software-modernisation.compassCTA-subheading %}</p>

--- a/src/_includes/get_in_touch.html
+++ b/src/_includes/get_in_touch.html
@@ -1,4 +1,5 @@
-{% include page_location_anchor.html anchor_id="get-in-touch" %}
+{%- assign anchor_id = {site.translations[site.lang].software-modernisation.page-sections.get-in-touch} -%}
+{% include page_location_anchor.html anchor_id=anchor_id %}
 <section class="get-in-touch">
   <div class="get-in-touch__inner">
     {% include section_intro.html description=include.description title=include.title %}

--- a/src/_includes/soft_mod_curated_publications.html
+++ b/src/_includes/soft_mod_curated_publications.html
@@ -1,7 +1,7 @@
 {% assign translations = site.translations[site.lang].curated-publications.softmod %}
 
 <div class="soft-mod__curated-publications">
-  {%- assign anchor_id = "publications" -%}
+  {%- assign anchor_id = {site.translations[site.lang].software-modernisation.page-sections.publications} -%}
   {% include page_location_anchor.html anchor_id=anchor_id %}
 
   {% include curated_publications.html tag="software modernisation" pinned_location="soft-mod" title=translations.intro-title description=translations.intro-description  %}

--- a/src/_includes/soft_mod_webinar_hero_teaser.html
+++ b/src/_includes/soft_mod_webinar_hero_teaser.html
@@ -5,7 +5,7 @@
 {% assign cta-href = teaser.cta-href %}
 {% assign image_position = 'left' %}
 {% capture image_src %}{{site.baseurl}}/assets/custom/img/softmod/softmod-in-distributed-worktimes-hero.jpg{% endcapture %}
-{%- assign anchor_id = "webinar" -%}
+{%- assign anchor_id = {site.translations[site.lang].software-modernisation.page-sections.webinar} -%}
 
 <div class="soft-mod__webinar-teaser">
   {% include page_location_anchor.html anchor_id=anchor_id %}

--- a/src/software-modernisation/index.html
+++ b/src/software-modernisation/index.html
@@ -38,7 +38,7 @@ metarobots: index,follow
 
 
 <section class="soft-mod-problems">
-  {%- assign anchor_id = "how-we-solve-your-problems" -%}
+  {%- assign anchor_id = {site.translations[site.lang].software-modernisation.page-sections.how-we-solve-your-problems} -%}
   {% include page_location_anchor.html anchor_id=anchor_id %}
 
   {% capture title %}{% t software-modernisation.problems-title %}{% endcapture %}
@@ -208,7 +208,7 @@ metarobots: index,follow
 </section>
 
 <section class="soft-mod__our-clients">
-  {%- assign anchor_id = "how-we-help-our-clients" -%}
+  {%- assign anchor_id = {site.translations[site.lang].software-modernisation.page-sections.how-we-help-our-clients} -%}
   {% include page_location_anchor.html anchor_id=anchor_id %}
   <div class="container">
 
@@ -285,7 +285,7 @@ metarobots: index,follow
 </section><!-- Case Studies -->
 
 <section class="soft-mod__testimonials">
-  {%- assign anchor_id = "testimonials" -%}
+  {%- assign anchor_id = {site.translations[site.lang].software-modernisation.page-sections.testimonials} -%}
   {% include page_location_anchor.html anchor_id=anchor_id %}
 
   {% capture title %}{% t software-modernisation.testimonials-heading %}{% endcapture %}


### PR DESCRIPTION
This PR puts the IDs for the Page Location Anchor component within the site's translation files. 
This way they can be customised between the EN and the ES version of the website. 