### PR TITLE
Ensure noindex pages are not added to the sitemap

### DIFF
--- a/src/services/service-line-template/index.html
+++ b/src/services/service-line-template/index.html
@@ -7,6 +7,7 @@ description-es: Spanish description for service line.
 image:
    src: /assets/custom/img/placeholders/meta-social-image.png
 metarobots: noindex,nofollow
+sitemap: false
 ---
 
 <script async src="https://cdn.jsdelivr.net/npm/simple-parallax-js@5.2.0/dist/simpleParallax.min.js"></script>

--- a/src/ui-components/hero-teaser/index.html
+++ b/src/ui-components/hero-teaser/index.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 metarobots: noindex,nofollow
+sitemap: false
 title: Hero Teaser | Codurance UI Components
 
 ---

--- a/src/ui-components/index.html
+++ b/src/ui-components/index.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 metarobots: noindex,nofollow
+sitemap: false
 title: Index | Codurance UI Components
 ---
 

--- a/src/ui-components/teaser-group/index.html
+++ b/src/ui-components/teaser-group/index.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 metarobots: noindex,nofollow
+sitemap: false
 title: Teaser Group | Codurance UI Components
 
 ---


### PR DESCRIPTION
@nicholemellekas I got an email from Google Console which was upset because we marked the template page as noindex,nofollow and added it to the sitemap.

This changes fixes that. It seemed quicker to just fix it than to discuss whether or not we have time to fix it. 