### PR TITLE
Hide curated publications when no posts

### DIFF
--- a/src/_i18n/en.yml
+++ b/src/_i18n/en.yml
@@ -827,6 +827,9 @@ curated-publications:
   softmod:
     intro-title: Software Modernisation publications
     intro-description: Discover related articles, podcasts, tools, and other resources to help you leverage new insights.
+  devops:
+    intro-title: Devops
+    intro-description: Devops bla bla bla
 
 service-line-template:
   hero-title: Lorum Ipsum

--- a/src/_i18n/en.yml
+++ b/src/_i18n/en.yml
@@ -827,9 +827,6 @@ curated-publications:
   softmod:
     intro-title: Software Modernisation publications
     intro-description: Discover related articles, podcasts, tools, and other resources to help you leverage new insights.
-  devops:
-    intro-title: Devops
-    intro-description: Devops bla bla bla
 
 service-line-template:
   hero-title: Lorum Ipsum

--- a/src/_includes/curated_publications.html
+++ b/src/_includes/curated_publications.html
@@ -17,6 +17,7 @@
     {% include hero_teaser.html class="curated-publications__hero" content_type=content_type cta=cta cta-href=cta-href description=description image_position="right" image_src=image_src title=title %}
   {% endfor %}
 
+  {% if posts.size > 1 %}
   <div class="curated-publications__cards cards-layout">
     <div class="cards-layout__inner">
       {% assign posts = site.posts | where: 'pinned_locations', include.pinned_location %}
@@ -46,11 +47,12 @@
     </div>
   </div>
 
-  <footer class="curated-publications__cta-space">
+  <div class="curated-publications__cta-space">
     {% capture href %}
       {{ site.baseurl }}/{{ site.tag_page_dir }}/{{ include.tag | slugify }}
     {% endcapture %}
     {% assign text = site.translations[site.lang].publications.view-all %}
     {% include cta_secondary_link.html class='curated-publications__cta' href=href text=text %}
-  </footer>
+  </div>
+  {% endif %}
 </section>

--- a/src/_includes/curated_publications.html
+++ b/src/_includes/curated_publications.html
@@ -18,41 +18,41 @@
   {% endfor %}
 
   {% if posts.size > 1 %}
-  <div class="curated-publications__cards cards-layout">
-    <div class="cards-layout__inner">
-      {% assign posts = site.posts | where: 'pinned_locations', include.pinned_location %}
-      {% for post in posts limit: 5 %}
-        {% if site.lang == "es" %}
-          {% assign article_title = post.title-es %}
-          {% assign article_description = post.description-es %}
-        {% else %}
-          {% assign article_title = post.title %}
-          {% assign article_description = post.description %}
-        {% endif %}
-        <article class="cards-layout__card card">
-          <a class="card__image-link" href="{{ post.url | prepend: site.baseurl }}">
-            <span class="card__image" style="background-image: url({{post.image.src | prepend: site.baseurl}})"></span>
-          </a>
-          <div class="card__main">
-            <h3 class="card__title">{{ article_title }}</h3>
-            <div class="card__description-fade-out">
-              <p class="card__description">{{ article_description }}</p>
+    <div class="curated-publications__cards cards-layout">
+      <div class="cards-layout__inner">
+        {% assign posts = site.posts | where: 'pinned_locations', include.pinned_location %}
+        {% for post in posts limit: 5 %}
+          {% if site.lang == "es" %}
+            {% assign article_title = post.title-es %}
+            {% assign article_description = post.description-es %}
+          {% else %}
+            {% assign article_title = post.title %}
+            {% assign article_description = post.description %}
+          {% endif %}
+          <article class="cards-layout__card card">
+            <a class="card__image-link" href="{{ post.url | prepend: site.baseurl }}">
+              <span class="card__image" style="background-image: url({{post.image.src | prepend: site.baseurl}})"></span>
+            </a>
+            <div class="card__main">
+              <h3 class="card__title">{{ article_title }}</h3>
+              <div class="card__description-fade-out">
+                <p class="card__description">{{ article_description }}</p>
+              </div>
             </div>
-          </div>
-          <a class="card__cta--text" href="{{ post.url | prepend: site.baseurl }}">
-            {% t publications.teaser-cta %}<i class="card__cta-decoration"></i>
-          </a>
-        </article>
-      {% endfor %}
+            <a class="card__cta--text" href="{{ post.url | prepend: site.baseurl }}">
+              {% t publications.teaser-cta %}<i class="card__cta-decoration"></i>
+            </a>
+          </article>
+        {% endfor %}
+      </div>
     </div>
-  </div>
 
-  <div class="curated-publications__cta-space">
-    {% capture href %}
-      {{ site.baseurl }}/{{ site.tag_page_dir }}/{{ include.tag | slugify }}
-    {% endcapture %}
-    {% assign text = site.translations[site.lang].publications.view-all %}
-    {% include cta_secondary_link.html class='curated-publications__cta' href=href text=text %}
-  </div>
+    <div class="curated-publications__cta-space">
+      {% capture href %}
+        {{ site.baseurl }}/{{ site.tag_page_dir }}/{{ include.tag | slugify }}
+      {% endcapture %}
+      {% assign text = site.translations[site.lang].publications.view-all %}
+      {% include cta_secondary_link.html class='curated-publications__cta' href=href text=text %}
+    </div>
   {% endif %}
 </section>

--- a/src/_includes/services_curated_publications.html
+++ b/src/_includes/services_curated_publications.html
@@ -1,4 +1,4 @@
-{% assign translations = site.translations[site.lang].curated-publications.softmod %}
+{% assign translations = site.translations[site.lang].curated-publications.[page.service-line] %}
 
 <div class="services__curated-publications">
   {%- assign anchor_id = {site.translations[site.lang].software-modernisation.page-sections.publications} -%}

--- a/src/_includes/services_curated_publications.html
+++ b/src/_includes/services_curated_publications.html
@@ -4,6 +4,6 @@
   {%- assign anchor_id = {site.translations[site.lang].software-modernisation.page-sections.publications} -%}
   {% include page_location_anchor.html anchor_id=anchor_id %}
 
-  {% include curated_publications.html tag="software modernisation" pinned_location="soft-mod" title=translations.intro-title description=translations.intro-description  %}
+  {% include curated_publications.html tag=include.tag pinned_location=include.pinned_location title=translations.intro-title description=translations.intro-description  %}
 </div>
 

--- a/src/_includes/services_curated_publications.html
+++ b/src/_includes/services_curated_publications.html
@@ -1,6 +1,6 @@
 {% assign translations = site.translations[site.lang].curated-publications.[include.service-line] %}
 
-<div class="services__curated-publications">
+<div class={{include.class}}>
   {%- assign anchor_id = {site.translations[site.lang].software-modernisation.page-sections.publications} -%}
   {% include page_location_anchor.html anchor_id=anchor_id %}
 

--- a/src/_includes/services_curated_publications.html
+++ b/src/_includes/services_curated_publications.html
@@ -1,4 +1,4 @@
-{% assign translations = site.translations[site.lang].curated-publications.[page.service-line] %}
+{% assign translations = site.translations[site.lang].curated-publications.[include.service-line] %}
 
 <div class="services__curated-publications">
   {%- assign anchor_id = {site.translations[site.lang].software-modernisation.page-sections.publications} -%}

--- a/src/_includes/services_curated_publications.html
+++ b/src/_includes/services_curated_publications.html
@@ -1,6 +1,6 @@
 {% assign translations = site.translations[site.lang].curated-publications.softmod %}
 
-<div class="soft-mod__curated-publications">
+<div class="services__curated-publications">
   {%- assign anchor_id = {site.translations[site.lang].software-modernisation.page-sections.publications} -%}
   {% include page_location_anchor.html anchor_id=anchor_id %}
 

--- a/src/_posts/2020-06-02-five-ways-to-lead-positive-change.md
+++ b/src/_posts/2020-06-02-five-ways-to-lead-positive-change.md
@@ -15,6 +15,7 @@ tags:
   - software modernisation
 pinned_locations:
   - soft-mod
+  - testytest
 ---
 
 ### Introduction  

--- a/src/_posts/2020-06-02-five-ways-to-lead-positive-change.md
+++ b/src/_posts/2020-06-02-five-ways-to-lead-positive-change.md
@@ -14,8 +14,8 @@ image:
 tags:
   - software modernisation
 pinned_locations:
+  - service-line-example-page
   - soft-mod
-  - testytest
 ---
 
 ### Introduction  

--- a/src/assets/custom/css/_sass/_services-curated-publications.scss
+++ b/src/assets/custom/css/_sass/_services-curated-publications.scss
@@ -1,0 +1,7 @@
+.services__curated-publications {
+  @include small {
+    .page-location-anchor {
+      top: calc(0px - #{$site-navbar-height-base});
+    }
+  }
+}

--- a/src/assets/custom/css/_sass/_services-curated-publications.scss
+++ b/src/assets/custom/css/_sass/_services-curated-publications.scss
@@ -7,8 +7,11 @@
 }
 
 .services__curated-publications--one-publication {
-   margin-top: -150px;
-   @include small {
+  margin-top: -150px;
+
+  @include small {
+    display: none;
+
     .page-location-anchor {
       top: calc(0px - #{$site-navbar-height-base});
     }

--- a/src/assets/custom/css/_sass/_services-curated-publications.scss
+++ b/src/assets/custom/css/_sass/_services-curated-publications.scss
@@ -5,3 +5,12 @@
     }
   }
 }
+
+.services__curated-publications--one-publication {
+   margin-top: -150px;
+   @include small {
+    .page-location-anchor {
+      top: calc(0px - #{$site-navbar-height-base});
+    }
+  }
+}

--- a/src/assets/custom/css/_sass/_soft-mod.scss
+++ b/src/assets/custom/css/_sass/_soft-mod.scss
@@ -53,14 +53,6 @@
   }
 }
 
-.soft-mod__curated-publications {
-  @include small {
-    .page-location-anchor {
-      top: calc(0px - #{$site-navbar-height-base});
-    }
-  }
-}
-
 .soft-mod__our-clients {
   background-color: $slate;
 

--- a/src/assets/custom/css/_sass/_soft-mod.scss
+++ b/src/assets/custom/css/_sass/_soft-mod.scss
@@ -41,6 +41,15 @@
   }
 }
 
+.soft-mod__sheen-container--one-publication{
+  background: $sheen;
+
+  @include medium-large-and-extra-large {
+    padding-top: $vertical-overlap;
+    padding-bottom: 120px;
+  }
+}
+
 .soft-mod__webinar-teaser {
   @include small {
     .page-location-anchor {

--- a/src/assets/custom/css/main.scss
+++ b/src/assets/custom/css/main.scss
@@ -28,6 +28,7 @@ $vertical-overlap: 100px;
 @import "flexslider";
 @import "home-page";
 @import "in-page-banner";
+@import "services-curated-publications";
 @import "services-page";
 @import "services-page-intro";
 @import "service-line-hero";

--- a/src/services/service-line-template/index.html
+++ b/src/services/service-line-template/index.html
@@ -209,7 +209,7 @@ sitemap: false
 
 <div class=soft-mod__sheen-container>
   {% include compass_teaser.html %}
-  {% include services_curated_publications.html service-line="devops" %}
+  {% include services_curated_publications.html service-line="softmod" %}
 </div>
 
 {% include services_contact_form.liquid %}

--- a/src/services/service-line-template/index.html
+++ b/src/services/service-line-template/index.html
@@ -210,7 +210,7 @@ sitemap: false
 <div class=soft-mod__sheen-container>
   {% include compass_teaser.html %}
   {% assign featured_posts =  site.posts | where: 'pinned_locations', "testytest" %}
-  {% if featured_posts != 0 %}
+  {% if featured_posts.size != 0 %}
     {% include services_curated_publications.html service-line="softmod" tag="software modernisation" pinned_location="testytest" %}
   {% endif %}
 </div>

--- a/src/services/service-line-template/index.html
+++ b/src/services/service-line-template/index.html
@@ -207,7 +207,7 @@ sitemap: false
   </div>
 </section>
 
-{% assign featured_posts =  site.posts | where: 'pinned_locations', "testytest" %}
+{% assign featured_posts =  site.posts | where: 'pinned_locations', "service-line-example-page" %}
 {% if featured_posts.size == 1 %}
   {% assign sheen_container_class = "soft-mod__sheen-container--one-publication" %}
   {% assign curated_publications_class = "services__curated-publications--one-publication" %}
@@ -220,7 +220,7 @@ sitemap: false
   {% include compass_teaser.html %}
 
   {% if featured_posts.size != 0 %}
-    {% include services_curated_publications.html class=curated_publications_class service-line="softmod" tag="software modernisation" pinned_location="testytest" %}
+    {% include services_curated_publications.html class=curated_publications_class service-line="softmod" tag="software modernisation" pinned_location="service-line-example-page" %}
   {% endif %}
 </div>
 

--- a/src/services/service-line-template/index.html
+++ b/src/services/service-line-template/index.html
@@ -209,7 +209,7 @@ sitemap: false
 
 <div class=soft-mod__sheen-container>
   {% include compass_teaser.html %}
-  {% include soft_mod_curated_publications.html %}
+  {% include services_curated_publications.html %}
 </div>
 
 {% include services_contact_form.liquid %}

--- a/src/services/service-line-template/index.html
+++ b/src/services/service-line-template/index.html
@@ -209,6 +209,7 @@ sitemap: false
 
 <div class=soft-mod__sheen-container>
   {% include compass_teaser.html %}
+  {% include soft_mod_curated_publications.html %}
 </div>
 
 {% include services_contact_form.liquid %}

--- a/src/services/service-line-template/index.html
+++ b/src/services/service-line-template/index.html
@@ -207,9 +207,16 @@ sitemap: false
   </div>
 </section>
 
-<div class=soft-mod__sheen-container>
+{% assign featured_posts =  site.posts | where: 'pinned_locations', "testytest" %}
+{% if featured_posts.size == 1 %}
+  {% assign class = "soft-mod__sheen-container--one-publication" %}
+{% else %}
+  {% assign class = "soft-mod__sheen-container" %}
+{% endif %}
+
+<div class={{class}}>
   {% include compass_teaser.html %}
-  {% assign featured_posts =  site.posts | where: 'pinned_locations', "testytest" %}
+
   {% if featured_posts.size != 0 %}
     {% include services_curated_publications.html service-line="softmod" tag="software modernisation" pinned_location="testytest" %}
   {% endif %}

--- a/src/services/service-line-template/index.html
+++ b/src/services/service-line-template/index.html
@@ -209,16 +209,18 @@ sitemap: false
 
 {% assign featured_posts =  site.posts | where: 'pinned_locations', "testytest" %}
 {% if featured_posts.size == 1 %}
-  {% assign class = "soft-mod__sheen-container--one-publication" %}
+  {% assign sheen_container_class = "soft-mod__sheen-container--one-publication" %}
+  {% assign curated_publications_class = "services__curated-publications--one-publication" %}
 {% else %}
-  {% assign class = "soft-mod__sheen-container" %}
+  {% assign sheen_container_class = "soft-mod__sheen-container" %}
+  {% assign curated_publications_class = "services__curated-publications" %}
 {% endif %}
 
-<div class={{class}}>
+<div class={{sheen_container_class}}>
   {% include compass_teaser.html %}
 
   {% if featured_posts.size != 0 %}
-    {% include services_curated_publications.html service-line="softmod" tag="software modernisation" pinned_location="testytest" %}
+    {% include services_curated_publications.html class=curated_publications_class service-line="softmod" tag="software modernisation" pinned_location="testytest" %}
   {% endif %}
 </div>
 

--- a/src/services/service-line-template/index.html
+++ b/src/services/service-line-template/index.html
@@ -209,7 +209,10 @@ sitemap: false
 
 <div class=soft-mod__sheen-container>
   {% include compass_teaser.html %}
-  {% include services_curated_publications.html service-line="softmod" %}
+  {% assign featured_posts =  site.posts | where: 'pinned_locations', "soft-mod" %}
+  {% if featured_posts != 0 %}
+    {% include services_curated_publications.html service-line="softmod" tag="software modernisation" pinned_location="soft-mod" %}
+  {% endif %}
 </div>
 
 {% include services_contact_form.liquid %}

--- a/src/services/service-line-template/index.html
+++ b/src/services/service-line-template/index.html
@@ -8,6 +8,7 @@ image:
    src: /assets/custom/img/placeholders/meta-social-image.png
 metarobots: noindex,nofollow
 sitemap: false
+service-line: devops
 ---
 
 <script async src="https://cdn.jsdelivr.net/npm/simple-parallax-js@5.2.0/dist/simpleParallax.min.js"></script>

--- a/src/services/service-line-template/index.html
+++ b/src/services/service-line-template/index.html
@@ -8,7 +8,6 @@ image:
    src: /assets/custom/img/placeholders/meta-social-image.png
 metarobots: noindex,nofollow
 sitemap: false
-service-line: devops
 ---
 
 <script async src="https://cdn.jsdelivr.net/npm/simple-parallax-js@5.2.0/dist/simpleParallax.min.js"></script>
@@ -210,7 +209,7 @@ service-line: devops
 
 <div class=soft-mod__sheen-container>
   {% include compass_teaser.html %}
-  {% include services_curated_publications.html %}
+  {% include services_curated_publications.html service-line="devops" %}
 </div>
 
 {% include services_contact_form.liquid %}

--- a/src/services/service-line-template/index.html
+++ b/src/services/service-line-template/index.html
@@ -209,9 +209,9 @@ sitemap: false
 
 <div class=soft-mod__sheen-container>
   {% include compass_teaser.html %}
-  {% assign featured_posts =  site.posts | where: 'pinned_locations', "soft-mod" %}
+  {% assign featured_posts =  site.posts | where: 'pinned_locations', "testytest" %}
   {% if featured_posts != 0 %}
-    {% include services_curated_publications.html service-line="softmod" tag="software modernisation" pinned_location="soft-mod" %}
+    {% include services_curated_publications.html service-line="softmod" tag="software modernisation" pinned_location="testytest" %}
   {% endif %}
 </div>
 

--- a/src/services/software-modernisation/index.html
+++ b/src/services/software-modernisation/index.html
@@ -320,7 +320,7 @@ redirect_from: /software-modernisation/
 <div class=soft-mod__sheen-container>
   {% include compass_teaser.html %}
   {% include soft_mod_webinar_hero_teaser.html %}
-  {% include soft_mod_curated_publications.html %}
+  {% include services_curated_publications.html %}
 </div>
 
 {% include services_contact_form.liquid %}

--- a/src/services/software-modernisation/index.html
+++ b/src/services/software-modernisation/index.html
@@ -320,7 +320,7 @@ redirect_from: /software-modernisation/
 <div class=soft-mod__sheen-container>
   {% include compass_teaser.html %}
   {% include soft_mod_webinar_hero_teaser.html %}
-  {% include services_curated_publications.html %}
+  {% include services_curated_publications.html service-line="softmod" tag="software modernisation" pinned_location="soft-mod" %}
 </div>
 
 {% include services_contact_form.liquid %}


### PR DESCRIPTION
This is for Leankit ticket 315: [Hide Curated Publications layout when there are no posts to show](https://codurance-online.leankit.com/card/1091867921)

If there are no publications with the tag of the current service-line, then none are shown.

If there are publications, they are shown (up to a maximum of 5).

If there is only one publication, it just shows the large (hero style) publication, with nothing underneath (we also thought it would make sense to remove the "view all publications" CTA for this case since there is only one publication to show.