### PR TITLE
Improve security on external links

### DIFF
--- a/src/assets/custom/js/externalLinks.js
+++ b/src/assets/custom/js/externalLinks.js
@@ -4,17 +4,26 @@ var openExternalLinksInNewTab = function () {
     return link.href.indexOf(origin) === 0;
   }
 
-  function hasExistingTarget(link) {
-    return !!link.target;
+  function hasNoTarget(link) {
+    return !link.target;
+  }
+
+  function hasNoRel(link) {
+    return !link.rel;
   }
 
   var links = window.document.querySelectorAll("a");
 
   Array.prototype.forEach.call(links, function (link) {
-    if (isInternal(link) || hasExistingTarget(link)) {
+    if (isInternal(link)) {
       return;
     }
-    link.target = "_blank";
+    if (hasNoTarget(link)) {
+      link.target = "_blank";
+    }
+    if (hasNoRel(link) && link.target === "_blank") {
+      link.rel = "noopener noreferrer";
+    }
   });
 };
 

--- a/src/assets/custom/js/externalLinks.test.js
+++ b/src/assets/custom/js/externalLinks.test.js
@@ -41,6 +41,11 @@ describe("External Links", () => {
       id: "linkWithExistingTarget",
       target: "_parent",
     });
+    addLink({
+      href: "https://another.com",
+      id: "linkWithNoRel",
+      target: "_blank",
+    });
     simulatePageLoad();
   });
 
@@ -56,5 +61,9 @@ describe("External Links", () => {
 
   it(`links that have a target defined are not changed`, () => {
     expect($("#linkWithExistingTarget").target).toBe("_parent");
+  });
+
+  it(`links that have a target but no rel are given the "noopener" rel`, () => {
+    expect($("#linkWithNoRel").rel).toBe("noopener noreferrer");
   });
 });

--- a/src/assets/custom/js/externalLinks.test.js
+++ b/src/assets/custom/js/externalLinks.test.js
@@ -63,7 +63,7 @@ describe("External Links", () => {
     expect($("#linkWithExistingTarget").target).toBe("_parent");
   });
 
-  it(`links that have a target but no rel are given the "noopener" rel`, () => {
+  it(`links that open in new tabs are given the "noopener" rel`, () => {
     expect($("#linkWithNoRel").rel).toBe("noopener noreferrer");
   });
 });


### PR DESCRIPTION
As [this post](https://www.manjuladube.dev/target-blank-security-vulnerability) explains, links with `target="_blank"` that don't have `rel="noopener noreferrer"` are a potential security threat.

These changes add to existing Javascript to ensure all our links to new tabs have this attribute.
