### PR TITLE
Rename apprentiship to academy

### DIFF
--- a/src/_i18n/en.yml
+++ b/src/_i18n/en.yml
@@ -434,10 +434,10 @@ careers:
     life_cover_icon: icon-medical-008 u-line-icon-pro
     mentor_title: Mentor
     mentor_description: You will choose a mentor, who will guide you throughout your apprenticeship.
-  become_an_apprentice:
-    title: Apprenticeship at Codurance
+  become_a_craftsperson_in_training:
+    title: Academy at Codurance
     apply_title: Apply now
-    description: Our apprentices share our passion for creating well-crafted software, but have not yet had the suitable learning opportunities to refine their craft.
+    description: Our craftspeople-in-training share our passion for creating well-crafted software, but have not yet had the suitable learning opportunities to refine their craft.
     how_works_title: How does it work?
     how_works_description: If you have a passion for learning and are ready for a chance to learn technologies and practices needed to gain peer-recognition of being at the level of a Software Craftsperson, then we look forward to receiving your application.
     how_works:
@@ -445,13 +445,13 @@ careers:
       box1_description: Hands-on, intensive modules covering the essentials of Software Design, XP practices, Clean Code and DDD.
       box2_title: Expert Guidance
       box2_description: You will be mentored by our Craftspeople, skilled professionals with a breadth and depth of expertise.
-      box3_title: Paid Apprenticeship
-      box3_description: We pay you a full-time salary throughout the Apprentice programme - essentially, we pay you to learn.
+      box3_title: Paid Academy
+      box3_description: We pay you a full-time salary throughout the Craftsperson-in-training programme - essentially, we pay you to learn.
       box4_title: Hands-On Learning
       box4_description: All concepts are taught through hands-on exercises, coding katas, group discussions and code reviews.
     skills:
       title: What skills & experience do I need
-      description: Our Apprentices join us from a wide range of different backgrounds and experiences. We value the diversity of experience and skill that each of the Apprentices brings to the course though, as a minimum, we require the following 'essential' skills for all Apprentices.
+      description: Our Craftspeople-in-training join us from a wide range of different backgrounds and experiences. We value the diversity of experience and skill that each of the Craftspeople-in-training brings to the course though, as a minimum, we require the following 'essential' skills for all Craftspeople-in-training.
       box1_title: Expected knowledge & skills
       box1_description: <li>Familiarity with C#, Java or Node.js tech stacks.</li>
         <li>Demonstrable attitude for self-learning and awareness of the need for quality and good practices.</li>
@@ -464,11 +464,11 @@ careers:
         <li>Be comfortable with OO design (SOLID, 4 rules of simple design, coupling/cohesion), DDD and design patterns.</li>
     apply_description: Interested in joining our teams in London, Manchester or Barcelona?
     testimonials:
-      title: Hear from past apprentices
-      description: At the end of the apprentice programme, our people seek peer-recognition of having reach the level of a Software Craftsperson and start to work alongside us on client projects.
+      title: Hear from past craftspeople-in-training
+      description: At the end of the craftsperson-in-training programme, our people seek peer-recognition of having reach the level of a Software Craftsperson and start to work alongside us on client projects.
       carousel_item_1:
         author: Liam Griffin-Jowett
-        quote: The impact was almost immeasurable in terms of growing as a developer. Giving me the space to focus purely on self-improvement, along with guidance so I didn't lose direction, was such a brilliant feeling. I learnt more during the months of my apprenticeship than I would have in many years in a normal developer role. Being paid to learn is awesome.
+        quote: The impact was almost immeasurable in terms of growing as a developer. Giving me the space to focus purely on self-improvement, along with guidance so I didn't lose direction, was such a brilliant feeling. I learnt more during the months of my academy than I would have in many years in a normal developer role. Being paid to learn is awesome.
       carousel_item_2:
         author: Luciano Palma
         quote: I felt that the journey was more valuable than the graduation itself. Learning through failure, receiving feedback and improving myself in the process. I now feel more confident in working in a team, exposing my ideas and receiving feedback from my colleagues.
@@ -492,10 +492,10 @@ careers:
     is_it_for_me_title: Is this the programme for me?
     is_it_for_me_description: If you have a passion for learning and are ready for a chance to learn technologies and practices needed to become a Software Craftsperson, under the guidance of a dedicated mentor, then we look forward to receiving your application.
     how_long_title: How long does it last
-    how_long_description: Your mentor will guide you through your apprenticeship which we expect to be a maximum of 6 months. There is no formal exam at the end - when your mentor is convinced that you are ready, and can convince at least 3 other craftspeople as well, then you graduate.
-    life_apprentice:
-      title: Life as an apprentice
-      description: Want to get a feel of what life as an apprentice is like? These blogs from our current and recent apprentices will show you what you can expect when you begin your journey with us.
+    how_long_description: Your mentor will guide you through your academy which we expect to be a maximum of 6 months. There is no formal exam at the end - when your mentor is convinced that you are ready, and can convince at least 3 other craftspeople as well, then you graduate.
+    life_craftsperson_in_training:
+      title: Life as a craftsperson-in-training
+      description: Want to get a feel of what life as a craftsperson-in-training is like? These blogs from our current and recent craftspeople-in-training will show you what you can expect when you begin your journey with us.
 careers-how_we_grow:
   title: How we grow?
   description: <p>Our people are our company and our product—our company grows as our people grow. The culture of learning is ingrained into our very core. Our fortnightly catchups are focused around learning from each other, and we run many internal sessions to build technologies expertise and hone our skills. We encourage and support each other to write blogs, record videos, organise community sessions, and present at conferences.</p>

--- a/src/_i18n/en.yml
+++ b/src/_i18n/en.yml
@@ -341,8 +341,8 @@ careers:
   our_roles_title: Our Roles
   software_craftspeople_title: Software Craftspeople
   software_craftspeople_description: Our Craftspeople have a broad range of skills and varying depths of expertise. Learn more about what it means to be a Craftsperson.
-  apprentices_title: Apprentices
-  apprentices_description: An intensive 3-month programme of learning that will provide you with the skills required to become a productive Craftsperson. Learn more about the programme here.
+  craftspeople_in_training_title: Craftspeople-in-training
+  craftspeople_in_training_description: An intensive 3-month programme of learning that will provide you with the skills required to become a productive Craftsperson. Learn more about the programme here.
   contact_us_title: Still have questions?
   contact_us_subtitle: If you'd like to know more about Codurance before applying, feel free to drop us a message here. We'll answer your questions but will respect your privacy. Once you're ready to apply, then we can talk further.
   life_at_codurance_title: Life at Codurance

--- a/src/_i18n/en.yml
+++ b/src/_i18n/en.yml
@@ -445,13 +445,13 @@ careers:
       box1_description: Hands-on, intensive modules covering the essentials of Software Design, XP practices, Clean Code and DDD.
       box2_title: Expert Guidance
       box2_description: You will be mentored by our Craftspeople, skilled professionals with a breadth and depth of expertise.
-      box3_title: Paid Academy
-      box3_description: We pay you a full-time salary throughout the Craftsperson-in-training programme - essentially, we pay you to learn.
+      box3_title: Paid Apprenticeship
+      box3_description: We pay you a full-time salary through the Academy programme - essentially, we pay you to learn.
       box4_title: Hands-On Learning
       box4_description: All concepts are taught through hands-on exercises, coding katas, group discussions and code reviews.
     skills:
       title: What skills & experience do I need
-      description: Our Craftspeople-in-training join us from a wide range of different backgrounds and experiences. We value the diversity of experience and skill that each of the Craftspeople-in-training brings to the course though, as a minimum, we require the following 'essential' skills for all Craftspeople-in-training.
+      description: Our Craftspeople-in-training join us from a wide range of different backgrounds and experiences. We value the diversity of experience and skill that each professional brings to the course though, as a minimum, we require the following 'essential' skills for all Craftspeople-in-training.
       box1_title: Expected knowledge & skills
       box1_description: <li>Familiarity with C#, Java or Node.js tech stacks.</li>
         <li>Demonstrable attitude for self-learning and awareness of the need for quality and good practices.</li>
@@ -465,7 +465,7 @@ careers:
     apply_description: Interested in joining our teams in London, Manchester or Barcelona?
     testimonials:
       title: Hear from past craftspeople-in-training
-      description: At the end of the craftsperson-in-training programme, our people seek peer-recognition of having reach the level of a Software Craftsperson and start to work alongside us on client projects.
+      description: At the end of the academy programme, our people seek peer-recognition of having reach the level of a Software Craftsperson and start to work alongside us on client projects.
       carousel_item_1:
         author: Liam Griffin-Jowett
         quote: The impact was almost immeasurable in terms of growing as a developer. Giving me the space to focus purely on self-improvement, along with guidance so I didn't lose direction, was such a brilliant feeling. I learnt more during the months of my academy than I would have in many years in a normal developer role. Being paid to learn is awesome.
@@ -535,7 +535,7 @@ careers-join-how_to_apply:
                <p>An up-to-date CV is always helpful. We also want links to your blogs, source repos, and any other media that well help us understand your professional side.</p>
 careers-open_positions:
   title: You like to build well-crafted software, we do too!
-  description: We are looking for people who share the same values of Software Craftsmanship that we do. Whether you’re an experienced Craftsperson or an aspiring Apprentice.
+  description: We are looking for people who share the same values of Software Craftsmanship that we do. Whether you’re an experienced Craftsperson or an aspiring Craftsperson-in-training.
 careers-become_a_craftsman:
   title: Become a Craftsperson
   description: <p>You have a strong desire to build quality software, to constantly improve yourself, and to help others to do the same. You have a broad appreciation for technology, with a deep knowledge of either <strong>Java</strong>, <strong>.NET</strong> or <strong>Node.js</strong> stacks.</p>

--- a/src/_i18n/es.yml
+++ b/src/_i18n/es.yml
@@ -452,9 +452,9 @@ careers:
       box1_title: Programa de 3 meses
       box1_description: Módulos prácticos e intensivos que cubren los aspectos esenciales del diseño de software, prácticas de XP, código limpio y DDD.
       box2_title: Orientación experta
-      box2_description: Estarás guiado/a por nuestros artesanos, profesionales altamente cualificados y con gran experiencia.
+      box2_description: Estarás guiado/a por nuestros Craftsperson, profesionales altamente cualificados y con gran experiencia.
       box3_title: Aprendizaje pagado
-      box3_description: Te pagamos un salario de a tiempo completo a través del programa de craftspeople-in-training. Resumiendo; cobrarás mientras aprendes.
+      box3_description: Te pagamos un salario de a tiempo completo a través del Academy program. Resumiendo; cobrarás mientras aprendes.
       box4_title: Aprendizaje práctico
       box4_description: Todos los conceptos se enseñan a través de ejercicios prácticos, katas, discusiones grupales y revisiones de código.
     skills:

--- a/src/_i18n/es.yml
+++ b/src/_i18n/es.yml
@@ -442,10 +442,10 @@ careers:
     life_cover_icon: icon-education-153 u-line-icon-pro
     mentor_title: Mentor
     mentor_description: Podrás escoger un mentor/a que te guíe en tu proceso de aprendizaje.
-  become_an_apprentice:
-    title: Aprendizaje en Codurance
+  become_a_craftsperson_in_training:
+    title: Academy en Codurance
     apply_title: Inscríbete
-    description: Los/as aprendices comparten nuestra pasión por crear software bien diseñado, pero aún no han tenido las oportunidades de aprendizaje adecuadas para refinar su oficio.
+    description: Los/as craftspeople-in-training comparten nuestra pasión por crear software bien diseñado, pero aún no han tenido las oportunidades de aprendizaje adecuadas para refinar su oficio.
     how_works_title: ¿Cómo trabajamos?
     how_works_description: Si tienes pasión por aprender y te gustaría tener la oportunidad de aprender las tecnologías y prácticas necesarias para convertirte en craftsperson esperamos tu solicitud.
     how_works:
@@ -454,12 +454,12 @@ careers:
       box2_title: Orientación experta
       box2_description: Estarás guiado/a por nuestros artesanos, profesionales altamente cualificados y con gran experiencia.
       box3_title: Aprendizaje pagado
-      box3_description: Te pagamos un salario de a tiempo completo a través del programa de aprendices. Resumiendo; cobrarás mientras aprendes.
+      box3_description: Te pagamos un salario de a tiempo completo a través del programa de craftspeople-in-training. Resumiendo; cobrarás mientras aprendes.
       box4_title: Aprendizaje práctico
       box4_description: Todos los conceptos se enseñan a través de ejercicios prácticos, katas, discusiones grupales y revisiones de código.
     skills:
       title: ¿Qué skills y experiencia necesitas?
-      description: Nuestros aprendices se unen al equipo Codurance con unos antecedentes y experiencias muy diferentes. Valoramos la diversidad de experiencias y habilidades que cada uno aporta al programa, aunque, una serie de habilidades básicas que necesitas tener.
+      description: Nuestros craftspeople-in-training se unen al equipo Codurance con unos antecedentes y experiencias muy diferentes. Valoramos la diversidad de experiencias y habilidades que cada uno aporta al programa, aunque, una serie de habilidades básicas que necesitas tener.
       box1_title: Conocimientos y skills requeridos.
       box1_description: <li>Familirizado con C#, Java or Node.js tech stacks.</li>
         <li>Actitud demostrable para el autoaprendizaje y estar alineado con la importancia y la necesidad de calidad y buenas prácticas en el desarrollo de software.</li>
@@ -472,11 +472,11 @@ careers:
         <li>Sentirse cómodo con OO design (SOLID, 4 reglas del simple design, coupling/cohesion), DDD y design patterns.</li>
     apply_description: ¿Quieres formar parte de alguno de nuestros equipos en Londres, Manchester or Barcelona?
     testimonials:
-      title: Testimonios de algunos de nuestros aprendices
-      description: Cuando acaba el programa de aprendizaje, se obtiene el reconocimiento de haber alcanzado el nivel de Software Craftsperson y en ese momento se empieza a trabajar en proyectos para clientes.
+      title: Testimonios de algunos de nuestros craftspeople-in-training
+      description: Cuando acaba el programa de academy, se obtiene el reconocimiento de haber alcanzado el nivel de Software Craftsperson y en ese momento se empieza a trabajar en proyectos para clientes.
       carousel_item_1:
         author: Liam Griffin-Jowett
-        quote: El impacto fue enorme en términos de crecimiento como desarrollador. Encontrar el espacio para concentrarme exclusivamente en la superación personal, unido a contar con la orientación necesaria para no perder la dirección, fue algo que me hizo sentir especialmente bien. Aprendí más durante los meses de mi aprendizaje que en muchos años en mi un rol habitual de desarrollador. Y poder cobrar un sueldo mientras aprendes es increíble.
+        quote: El impacto fue enorme en términos de crecimiento como desarrollador. Encontrar el espacio para concentrarme exclusivamente en la superación personal, unido a contar con la orientación necesaria para no perder la dirección, fue algo que me hizo sentir especialmente bien. Aprendí más durante los meses de mi academy que en muchos años en mi un rol habitual de desarrollador. Y poder cobrar un sueldo mientras aprendes es increíble.
       carousel_item_2:
         author: Luciano Palma
         quote: Sentí que el proceso era más valioso que la graduación en sí misma. He podido aprender a través de los errores, recibir feedback y mejorar continuamente durante el proceso. Ahora me siento más seguro trabajando en equipo, exponiendo mis ideas y recibiendo el feedback de mis colegas..
@@ -498,13 +498,13 @@ careers:
     background_title: ¿Qué experiencia necesitas?
     background_description:
       Esperamos que te desenvuelvas en al menos un idioma que elijas en las plataformas JVM, .NET y / o Node JS. También que conozcas las metodologías Agile y que puedas aplicarlas. Necesitas tener conocimientos básicos de diseño a nivel micro y macro.Te desenvuelves correctamente comunicando tus ideas en equipo. Te apasiona aprender y perfeccionar tus habilidades como desarrollador de software. Te gusta tanto aprender como enseñar.
-    is_it_for_me_title: El programa de aprendizaje ¿es para mí?
+    is_it_for_me_title: El programa de academy ¿es para mí?
     is_it_for_me_description: Si estás buscando un programa de aprendizaje estructurado, con certificaciones, una titulación, módulos de aprendizaje y cursos de capacitación regulares este no es el programa que necesitas. Sin embargo, si estás buscando una formación intensa sobre lo que significa ser un Software Craftsperson, acompañado por un mentor, que te ayude a prender las tecnologías, prácticas y habilidades del mundo real necesarias , esperamos recibir tu solicitud para formar parte del programa.
     how_long_title: ¿Cuánto tiempo dura el programa?
     how_long_description: Aproximadamente unos 3 meses, pero será tu mentor quien te guiará en este camino. Al final no hay examen. Cuando tu mentor consideré que estás preparado y otros 3 craftsperson consideren que lo estás podrás graduarte.
-    life_apprentice:
+    life_craftsperson_in_training:
       title: La vida del aprendiz.
-      description: ¿Quieres tener una idea de cómo es la vida como aprendiz? Estos testimonios de algunos de nuestros aprendices te pueden dar una idea de lo que significa embarcarte en este viaje.
+      description: ¿Quieres tener una idea de cómo es la vida como aprendiz? Estos testimonios de algunos de nuestros craftspeople-in-training te pueden dar una idea de lo que significa embarcarte en este viaje.
 careers-how_we_grow:
   title: ¿Cómo crecemos?
   description: <p>Nuestra gente es nuestra empresa y nuestro producto, nuestra empresa crece como crece nuestra gente. La cultura de aprendizaje está arraigada a nuestra esencia. Nuestros encuentros quincenales se centran en torno al aprendizaje de los demás, en ellos realizamos muchas sesiones internas para compartir experiencias tecnológicas y perfeccionar nuestras habilidades. Nos alentamos y apoyamos unos a otros para escribir blogs, grabar vídeos, organizar sesiones en la comunidad y para presentar en conferencias.</p>

--- a/src/_i18n/es.yml
+++ b/src/_i18n/es.yml
@@ -348,8 +348,8 @@ careers:
   our_roles_title: Nuestros Roles
   software_craftspeople_title: Software Craftspeople
   software_craftspeople_description: Nuestros Craftspeople tienen una habilidades y niveles de experiencia muy diversos. Infórmate sobre lo que significa ser un Craftsperson.
-  apprentices_title: Aprendices
-  apprentices_description: Un programa intensivo de aprendizaje de 3 meses que te proporcionará las habilidades necesarias para convertirte en Craftsperson. Infórmate sobre el programa.
+  craftspeople_in_training_title: Craftspeople-in-training
+  craftspeople_in_training_description: Un programa intensivo de aprendizaje de 3 meses que te proporcionará las habilidades necesarias para convertirte en Craftsperson. Infórmate sobre el programa.
   contact_us_title: ¿Tienes más preguntas?
   contact_us_subtitle: Si necesitas más información sobre Codurance antes de aplicar, siéntete libre de enviarnos un mensaje y preguntarnos lo que necesites. Responderemos a tus preguntas y respetaremos tu privacidad. Cuando hayas recabado la información que necesitas y estés listo/a para presentar tu candidatura hablaremos al respecto.
   life_at_codurance_title: Vida en Codurance

--- a/src/careers/become_a_craftsperson_in_training.html
+++ b/src/careers/become_a_craftsperson_in_training.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Apprenticeship at Codurance
+title: Academy at Codurance
 category: careers
 redirect_from:
     - /work-with-us/apprentice/
@@ -12,11 +12,11 @@ redirect_from:
     <div class="divimage dzsparallaxer--target w-100 u-bg-overlay g-bg-black-opacity-0_3--after" style="height: 140%; background-image: url({{ site.baseurl }}/assets/custom/img/careers/careers_hero.jpg); transform: translate3d(0px, -40.0274px, 0px);"></div>
     <div class="container g-color-white text-center g-py-120">
         <div class="u-heading-v2-6--bottom g-brd-primary g-mb-40">
-            <h2 class="text-uppercase u-heading-v2__title g-mb-10">{% t careers.become_an_apprentice.title %}</h2>
-            <h4 class="g-font-weight-200">{% t careers.become_an_apprentice.description %}</h4>
+            <h2 class="text-uppercase u-heading-v2__title g-mb-10">{% t careers.become_a_craftsperson_in_training.title %}</h2>
+            <h4 class="g-font-weight-200">{% t careers.become_a_craftsperson_in_training.description %}</h4>
         </div>
         <div class="text-center">
-            <a class="btn btn-md u-btn-primary text-uppercase g-mb-15" href="#apprentice-form"  data-modal-target="#apprentice-form">{% t careers.become_an_apprentice.apply_title %}</a>
+            <a class="btn btn-md u-btn-primary text-uppercase g-mb-15" href="#apprentice-form"  data-modal-target="#apprentice-form">{% t careers.become_a_craftsperson_in_training.apply_title %}</a>
         </div>
     </div>
 </section>
@@ -27,14 +27,14 @@ redirect_from:
     <div class="container content-md">
         <div class="text-center margin-bottom-60">
             <div class="text-center mb-4">
-                <h2 class="h3 text-uppercase mb-3">{% t careers.become_an_apprentice.how_works_title %}</h2>
+                <h2 class="h3 text-uppercase mb-3">{% t careers.become_a_craftsperson_in_training.how_works_title %}</h2>
                 <div class="d-inline-block g-width-60 g-height-1 g-bg-orange mb-2"></div>
             </div>
 
             {% include apply_form.html target="apprentice" %}
 
             <div class="row margin-bottom-20">
-                <p class="space-lg-hor">{% t careers.become_an_apprentice.how_works_description %}</p>
+                <p class="space-lg-hor">{% t careers.become_a_craftsperson_in_training.how_works_description %}</p>
             </div>
         </div>
 
@@ -48,8 +48,8 @@ redirect_from:
                         <div class="g-bg-white g-pa-20 h-90 howworks-box">
                             <div class="media g-mb-15">
                                 <div class="media-body">
-                                    <h3 class="h5 g-color-black mb-20">{% t careers.become_an_apprentice.how_works.box1_title %}</h3>
-                                    <p class="g-color-gray-dark-v4 g-mb-0">{% t careers.become_an_apprentice.how_works.box1_description %}</p>
+                                    <h3 class="h5 g-color-black mb-20">{% t careers.become_a_craftsperson_in_training.how_works.box1_title %}</h3>
+                                    <p class="g-color-gray-dark-v4 g-mb-0">{% t careers.become_a_craftsperson_in_training.how_works.box1_description %}</p>
                                 </div>
                             </div>
                         </div>
@@ -58,8 +58,8 @@ redirect_from:
                         <div class="g-bg-white g-pa-20 h-90 howworks-box">
                             <div class="media g-mb-15">
                                 <div class="media-body">
-                                    <h3 class="h5 g-color-black mb-20"> {% t careers.become_an_apprentice.how_works.box2_title %}</h3>
-                                    <p class="g-color-gray-dark-v4 g-mb-0">{% t careers.become_an_apprentice.how_works.box2_description %}</p>
+                                    <h3 class="h5 g-color-black mb-20"> {% t careers.become_a_craftsperson_in_training.how_works.box2_title %}</h3>
+                                    <p class="g-color-gray-dark-v4 g-mb-0">{% t careers.become_a_craftsperson_in_training.how_works.box2_description %}</p>
                                 </div>
                             </div>
                         </div>
@@ -70,8 +70,8 @@ redirect_from:
                             <div class="g-bg-white g-pa-20 h-90 howworks-box">
                                 <div class="media g-mb-15">
                                     <div class="media-body">
-                                        <h3 class="h5 g-color-black mb-20">{% t careers.become_an_apprentice.how_works.box3_title %} </h3>
-                                        <p class="g-color-gray-dark-v4 g-mb-0">{% t careers.become_an_apprentice.how_works.box3_description %}</p>
+                                        <h3 class="h5 g-color-black mb-20">{% t careers.become_a_craftsperson_in_training.how_works.box3_title %} </h3>
+                                        <p class="g-color-gray-dark-v4 g-mb-0">{% t careers.become_a_craftsperson_in_training.how_works.box3_description %}</p>
                                     </div>
                                 </div>
                             </div>
@@ -80,8 +80,8 @@ redirect_from:
                             <div class="g-bg-white g-pa-20 h-90 howworks-box">
                                 <div class="media g-mb-15">
                                     <div class="media-body">
-                                        <h3 class="h5 g-color-black mb-20">{% t careers.become_an_apprentice.how_works.box4_title %}</h3>
-                                        <p class="g-color-gray-dark-v4 g-mb-0">{% t careers.become_an_apprentice.how_works.box4_description %}</p>
+                                        <h3 class="h5 g-color-black mb-20">{% t careers.become_a_craftsperson_in_training.how_works.box4_title %}</h3>
+                                        <p class="g-color-gray-dark-v4 g-mb-0">{% t careers.become_a_craftsperson_in_training.how_works.box4_description %}</p>
                                     </div>
                                 </div>
                             </div>
@@ -98,25 +98,25 @@ redirect_from:
     <div class="container content-md">
         <div class="text-center margin-bottom-60">
             <div class="text-center mb-4">
-                <h2 class="h3 text-uppercase mb-3">{% t careers.become_an_apprentice.skills.title %}</h2>
+                <h2 class="h3 text-uppercase mb-3">{% t careers.become_a_craftsperson_in_training.skills.title %}</h2>
                 <div class="d-inline-block g-width-60 g-height-1 g-bg-orange mb-2"></div>
             </div>
             <div class="row margin-bottom-20">
-                <p class="space-lg-hor">{% t careers.become_an_apprentice.skills.description %}</p>
+                <p class="space-lg-hor">{% t careers.become_a_craftsperson_in_training.skills.description %}</p>
             </div>
         </div>
 
         <div class="row skills">
             <div class="col-lg-6 g-ma-0--lg g-mb-30">
-                <h5 class="title-v2">{% t careers.become_an_apprentice.skills.box1_title %}</h5>
+                <h5 class="title-v2">{% t careers.become_a_craftsperson_in_training.skills.box1_title %}</h5>
                 <ul class="skill-list">
-                    {% t careers.become_an_apprentice.skills.box1_description %}
+                    {% t careers.become_a_craftsperson_in_training.skills.box1_description %}
                 </ul>
              </div>
             <div class="col-lg-6">
-                <h5 class="title-v2">{% t careers.become_an_apprentice.skills.box2_title %}</h5>
+                <h5 class="title-v2">{% t careers.become_a_craftsperson_in_training.skills.box2_title %}</h5>
                 <ul class="skill-list">
-                    {% t careers.become_an_apprentice.skills.box2_description %}
+                    {% t careers.become_a_craftsperson_in_training.skills.box2_description %}
                 </ul>
             </div>
          </div>
@@ -128,10 +128,10 @@ redirect_from:
 <section class="g-bg-orange g-color-white g-pa-30">
     <div class="d-md-flex justify-content-md-center text-center">
         <div class="align-self-md-center">
-            <p class="lead g-font-weight-400 g-color-white g-mr-20--md g-mb-15 g-mb-0--md">{% t careers.become_an_apprentice.apply_description %}</p>
+            <p class="lead g-font-weight-400 g-color-white g-mr-20--md g-mb-15 g-mb-0--md">{% t careers.become_a_craftsperson_in_training.apply_description %}</p>
         </div>
         <div class="align-self-md-center">
-            <a class="btn btn-lg u-btn-white text-uppercase g-font-weight-600 g-font-size-12" data-modal-target="#apprentice-form" href="#craftsman-form">{% t careers.become_an_apprentice.apply_title %}</a>
+            <a class="btn btn-lg u-btn-white text-uppercase g-font-weight-600 g-font-size-12" data-modal-target="#apprentice-form" href="#craftsman-form">{% t careers.become_a_craftsperson_in_training.apply_title %}</a>
         </div>
     </div>
 </section>
@@ -142,12 +142,12 @@ redirect_from:
     <div class="container content-md">
         <div class="text-center margin-bottom-60">
             <div class="text-center mb-4">
-                <h2 class="h3 text-uppercase mb-3">{% t careers.become_an_apprentice.testimonials.title %}</h2>
+                <h2 class="h3 text-uppercase mb-3">{% t careers.become_a_craftsperson_in_training.testimonials.title %}</h2>
                 <div class="d-inline-block g-width-60 g-height-1 g-bg-orange mb-2">
                 </div>
             </div>
             <div class="row margin-bottom-20">
-                <p class="space-lg-hor">{% t careers.become_an_apprentice.testimonials.description %}</p>
+                <p class="space-lg-hor">{% t careers.become_a_craftsperson_in_training.testimonials.description %}</p>
             </div>
         </div>
 
@@ -170,12 +170,12 @@ redirect_from:
                                 </div>
                                 <div class="col-lg-8 col-md-8 col-sm-8 col-xs-8">
                                     <div>
-                                        <p class="h5 mb-1">{% t careers.become_an_apprentice.testimonials.carousel_item_1.author %}</p>
+                                        <p class="h5 mb-1">{% t careers.become_a_craftsperson_in_training.testimonials.carousel_item_1.author %}</p>
                                         <div class="d-inline-block g-width-60 g-height-1 g-bg-orange mb-2">
                                         </div>
                                     </div>
                                     <div class="quote">
-                                        <div class="curly-quotes">{% t careers.become_an_apprentice.testimonials.carousel_item_1.quote %}</div>
+                                        <div class="curly-quotes">{% t careers.become_a_craftsperson_in_training.testimonials.carousel_item_1.quote %}</div>
                                     </div>
                                 </div>
                             </div>
@@ -187,12 +187,12 @@ redirect_from:
                                 </div>
                                 <div class="col-lg-8 col-md-8 col-sm-8 col-xs-8">
                                     <div>
-                                        <p class="h5 mb-1">{% t careers.become_an_apprentice.testimonials.carousel_item_2.author %}</p>
+                                        <p class="h5 mb-1">{% t careers.become_a_craftsperson_in_training.testimonials.carousel_item_2.author %}</p>
                                         <div class="d-inline-block g-width-60 g-height-1 g-bg-orange mb-2">
                                         </div>
                                     </div>
                                     <div class="quote">
-                                        <div class="curly-quotes">{% t careers.become_an_apprentice.testimonials.carousel_item_2.quote %}</div>
+                                        <div class="curly-quotes">{% t careers.become_a_craftsperson_in_training.testimonials.carousel_item_2.quote %}</div>
                                     </div>
                                 </div>
                             </div>
@@ -209,9 +209,9 @@ redirect_from:
 <section class="g-py-50 g-pb-100 g-bg-gray-light-v5"">
     <div class="container">
         <div class="text-center mb-4">
-            <h2 class="h3 text-uppercase mb-3">{% t careers.become_an_apprentice.hiring_process.title %}</h2>
+            <h2 class="h3 text-uppercase mb-3">{% t careers.become_a_craftsperson_in_training.hiring_process.title %}</h2>
             <div class="d-inline-block g-width-60 g-height-1 g-bg-orange mb-2"></div>
-            <p class="lead mb-0">{% t careers.become_an_apprentice.hiring_process.subtitle %}</p>
+            <p class="lead mb-0">{% t careers.become_a_craftsperson_in_training.hiring_process.subtitle %}</p>
         </div>
         <!-- Icon Blocks -->
         <ul class="row list-inline u-info-v9-1 mb-0">
@@ -230,9 +230,9 @@ redirect_from:
                     </div>
                     <h3 class="g-color-primary g-font-weight-600 g-font-size-17 text-uppercase mb-3">
                         <span class="g-color-main g-font-weight-700">01.</span>
-                        {% t careers.become_an_apprentice.hiring_process.step_1.title %}
+                        {% t careers.become_a_craftsperson_in_training.hiring_process.step_1.title %}
                     </h3>
-                    <p>{% t careers.become_an_apprentice.hiring_process.step_1.description %}</p>
+                    <p>{% t careers.become_a_craftsperson_in_training.hiring_process.step_1.description %}</p>
                 </div>
                 <!-- End Icon Blocks -->
             </li>
@@ -251,9 +251,9 @@ redirect_from:
                     </div>
                     <h3 class="g-color-primary g-font-weight-600 g-font-size-17 text-uppercase mb-3">
                         <span class="g-color-main g-font-weight-700">02.</span>
-                        {% t careers.become_an_apprentice.hiring_process.step_2.title %}
+                        {% t careers.become_a_craftsperson_in_training.hiring_process.step_2.title %}
                     </h3>
-                    <p>{% t careers.become_an_apprentice.hiring_process.step_2.description %}</p>
+                    <p>{% t careers.become_a_craftsperson_in_training.hiring_process.step_2.description %}</p>
                 </div>
                 <!-- End Icon Blocks -->
             </li>
@@ -272,9 +272,9 @@ redirect_from:
                     </div>
                     <h3 class="g-color-primary g-font-weight-600 g-font-size-17 text-uppercase mb-3">
                         <span class="g-color-main g-font-weight-700">03.</span>
-                        {% t careers.become_an_apprentice.hiring_process.step_3.title %}
+                        {% t careers.become_a_craftsperson_in_training.hiring_process.step_3.title %}
                     </h3>
-                    <p>{% t careers.become_an_apprentice.hiring_process.step_3.description %}</p>
+                    <p>{% t careers.become_a_craftsperson_in_training.hiring_process.step_3.description %}</p>
                 </div>
                 <!-- End Icon Blocks -->
             </li>
@@ -293,9 +293,9 @@ redirect_from:
                     </div>
                     <h3 class="g-color-primary g-font-weight-600 g-font-size-17 text-uppercase mb-3">
                         <span class="g-color-main g-font-weight-700">04.</span>
-                        {% t careers.become_an_apprentice.hiring_process.step_4.title %}
+                        {% t careers.become_a_craftsperson_in_training.hiring_process.step_4.title %}
                     </h3>
-                    <p>{% t careers.become_an_apprentice.hiring_process.step_4.description %}</p>
+                    <p>{% t careers.become_a_craftsperson_in_training.hiring_process.step_4.description %}</p>
                 </div>
                 <!-- End Icon Blocks -->
             </li>

--- a/src/careers/become_a_craftsperson_in_training.html
+++ b/src/careers/become_a_craftsperson_in_training.html
@@ -4,6 +4,7 @@ title: Apprenticeship at Codurance
 category: careers
 redirect_from:
     - /work-with-us/apprentice/
+    - /careers/become_an_apprentice/
 ---
 
 <!-- Heading -->

--- a/src/careers/index.html
+++ b/src/careers/index.html
@@ -189,10 +189,10 @@ redirect_from:
                 <!-- Article -->
                 <article class="h-100 text-center info-v3-2 g-flex-middle g-bg-cover g-bg-size-cover g-bg-black-opacity-0_2--after g-color-white text-uppercase g-py-210 g-px-30" data-bg-img-src="{{ site.baseurl }}/assets/custom/img/careers/temp1.jpg">
                     <div class="flex-align-baseline g-pos-rel g-z-index-2">
-                        <h3 class="g-font-weight-700 g-letter-spacing-3 g-mb-20">{%t careers.apprentices_title %}</h3>
+                        <h3 class="g-font-weight-700 g-letter-spacing-3 g-mb-20">{%t careers.craftspeople_in_training_title %}</h3>
                     </div>
                     <div class="g-flex-middle-item g-pos-rel g-z-index-2">
-                        <em class="d-block g-letter-spacing-3 g-font-weight-300 g-font-style-normal g-mb-40">{%t careers.apprentices_description %}</em>
+                        <em class="d-block g-letter-spacing-3 g-font-weight-300 g-font-style-normal g-mb-40">{%t careers.craftspeople_in_training_description %}</em>
                     </div>
                     <div class="flex-align-bottom g-pos-rel g-z-index-2">
                         <a class="btn btn-md u-btn-primary text-uppercase btn-codurance-color" href="{{ site.baseurl }}/careers/become_an_apprentice">{% t careers.learn_more %}</a>

--- a/src/careers/index.html
+++ b/src/careers/index.html
@@ -195,7 +195,7 @@ redirect_from:
                         <em class="d-block g-letter-spacing-3 g-font-weight-300 g-font-style-normal g-mb-40">{%t careers.craftspeople_in_training_description %}</em>
                     </div>
                     <div class="flex-align-bottom g-pos-rel g-z-index-2">
-                        <a class="btn btn-md u-btn-primary text-uppercase btn-codurance-color" href="{{ site.baseurl }}/careers/become_an_apprentice">{% t careers.learn_more %}</a>
+                        <a class="btn btn-md u-btn-primary text-uppercase btn-codurance-color" href="{{ site.baseurl }}/careers/become_a_craftsperson_in_training">{% t careers.learn_more %}</a>
                     </div>
                 </article>
                 <!-- End Article -->


### PR DESCRIPTION
Related to #1822 

- [x] rename the page https://codurance.es/careers/become_an_apprentice/ to https://codurance.es/careers/become_a_craftsperson_in_training/ with redirection.
- [x] update wording at https://codurance.com/careers/ at https://codurance.es/careers/
- [x] update contents in https://codurance.com/careers/become_an_apprentice/ and https://codurance.es/careers/careers/become_an_apprentice/