### PR TITLE
Remove broken redirect

### DIFF
--- a/src/services/service-line-example/index.html
+++ b/src/services/service-line-example/index.html
@@ -19,7 +19,6 @@ curated_publications:
 
 service-line: service-line-example
 
-redirect_from: /services/service-line-template
 ---
 
 


### PR DESCRIPTION
We found that our redirect of `/services/service-line-template` is not working as expected. Rather than burn time looking into it we're simply removing it to not cause confusion in future.