### PR TITLE
Moving from Google Hire to Workable

### DIFF
--- a/src/_includes/apply_form.html
+++ b/src/_includes/apply_form.html
@@ -1,9 +1,34 @@
 <div id="{{ include.target }}-form" class="g-max-width-800 g-bg-white g-overflow-y-auto g-brd-around g-brd-gray-light-v4 g-pa-20 g-mb-40" style="display: none;">
   <button type="button" class="close" onclick="Custombox.modal.close();"> <i class="hs-icon hs-icon-close btn-pointer-cursor"></i> </button>
-  <h4 class="modal-title" id="myModalLabel4">Current Positions</h4>
-  <hr></hr>
+  <h2 class="modal-title" id="myModalLabel4">Current Positions</h2>
+  <div class="small g-color-grey-opacity-0_6">Note: Links below will open in a new tab.</div>
+  <hr>
+  <script src='https://www.workable.com/assets/embed.js' type='text/javascript'></script>
+  <script type='text/javascript' charset='utf-8'>
+    whr(document).ready(function(){
+      window.addEventListener('load', function(e) {
+        var locations = document.getElementsByClassName('whr-location');
+        for (var i = 0; i < locations.length; i++) {
+          locations[i].innerText = locations[i].innerText.replace(/(England, |Catalonia, )/, '');
+        }
+      });
 
-  <div class="small g-color-grey-opacity-0_6">Note: Links bellow will open in a new tab.</div>
-  <div class="hire-jobs"></div>
-  <script id="hire-embed-loader" async defer src="https://hire.withgoogle.com/s/embed/hire-jobs.js?company=codurancecom"></script>
+      whr_embed(342253, {detail: 'titles', base: 'jobs', zoom: 'country', grouping: 'locations'});
+      whr(document).on('click', 'li.whr-item a', function(e) {
+        e.preventDefault(); window.open(this.href, '_blank');
+      });
+    });
+  </script>
+  <style>
+    .whr-code, .whr-date {
+      display: none;
+    }
+    .whr-group {
+      font-weight: bold;
+    }
+    .whr-items {
+      margin-right: 1em;
+    }
+  </style>
+  <div id="whr_embed_hook"></div>
 </div>


### PR DESCRIPTION
This PR will replace Google Hire with Workable hiring app.

Using script provided by Workable to embed jobs on a website.
https://help.workable.com/hc/en-us/articles/115012801727-How-to-embed-jobs-on-your-website