### PR TITLE
Update cookie name to match cookie that is used

### DIFF
--- a/src/policies/cookie.html
+++ b/src/policies/cookie.html
@@ -36,7 +36,7 @@ title: Cookie Policy
                 </thead>
                 <tbody>
                     <tr style="border-bottom: 1px solid #777">
-                        <td style="padding: 0.8rem 0.8rem 0.8rem 0;">seen-cookie-message</td>
+                        <td style="padding: 0.8rem 0.8rem 0.8rem 0;">has-cookie-consent</td>
                         <td style="text-align: left; padding: 0.8rem 0.8rem 0.8rem 0;">Used to indicate you have seen the cookie message</td>
                         <td style="padding: 0.8rem 0.8rem 0.8rem 0;">30 days</td>
                     </tr>


### PR DESCRIPTION
The cookie that is created when a user accepts cookies is called 'has-cookie-consent' not 'seen-cookie-message'. Updated the name in the Cookie Policy page to reflect that.