### PR TITLE
Ensure tab has a 50/50 split of content width

### DIFF
--- a/src/assets/custom/css/_sass/_tabber.scss
+++ b/src/assets/custom/css/_sass/_tabber.scss
@@ -114,6 +114,9 @@
   @include small-and-medium {
     padding: 15px 15px 30px;
   }
+  @include large-and-extra-large {
+    width: 50%;
+  }
   @include large {
     padding: 30px;
   }


### PR DESCRIPTION
This fixes an issue with the blue and white areas not always being the same width.

See **before** and **after** shots here: 
<img width="1023" alt="Screenshot 2020-06-24 at 15 49 21" src="https://user-images.githubusercontent.com/353044/85578877-50e49880-b632-11ea-81c5-9fccb65be69f.png">


<img width="1022" alt="Screenshot 2020-06-24 at 15 48 56" src="https://user-images.githubusercontent.com/353044/85578860-4de9a800-b632-11ea-9af1-640de9708621.png">
