### PR TITLE
Add translated copy for services page clients teaser

### DIFF
--- a/src/_i18n/en.yml
+++ b/src/_i18n/en.yml
@@ -201,6 +201,7 @@ services:
     image: http://placekitten.com/780/590
     cta-href: /services/training
     cta-text: Learn more
+  clients-teaser-title: You're in good company
 services-training_coaching:
   title: Training & Coaching
   our_courses: Our Courses

--- a/src/_i18n/es.yml
+++ b/src/_i18n/es.yml
@@ -201,12 +201,6 @@ services:
     title: Contacta con nosotros
     body: Contacta con nosotros para averiguar cómo podemos colaborar.
     formid: 3723c6ef-7d66-438a-9c3c-7a1d8aebd3da
-  training:
-    title: Trainings
-    description: Construye un equipo en el que puedas confiar para la ejecución de tu proyecto. Ayudamos a tus equipos a desarrollar las habilidades que necesitan para destacar en cada área de la entrega de producto.<br/><br/>Nuestros expertos aportarán años de lecciones aprendidas al frente de sistemas de misión crítica en una amplia gama de tecnologías con las que tu negocio se verá beneficiado.
-    image: http://placekitten.com/780/590
-    cta-href: /services/training
-    cta-text: Cómo lo hacemos
 services-training_coaching:
   title: Formación & asesoría
   our_courses: Nuestros cursos

--- a/src/_i18n/es.yml
+++ b/src/_i18n/es.yml
@@ -197,6 +197,7 @@ services:
     description: Construye un equipo en el que puedas confiar para la ejecución de tu proyecto. Ayudamos a tus equipos a desarrollar las habilidades que necesitan para destacar en cada área de la entrega de producto. Nuestros expertos aportarán años de lecciones aprendidas al frente de sistemas de misión crítica en una amplia gama de tecnologías con las que tu negocio se verá beneficiado.
     cta-text: Cómo lo hacemos
     cta-href: /services/trainings
+  clients-teaser-title: Estos son algunos de nuestros clientes
   contact-us:
     title: Contacta con nosotros
     body: Contacta con nosotros para averiguar cómo podemos colaborar.

--- a/src/services/index.html
+++ b/src/services/index.html
@@ -14,7 +14,8 @@ metarobots: index,follow
   {% include services_page_intro.liquid %}
   {% include service_line_teaser_group.html %}
   {% include training_teaser.html class="services-page__training-teaser" %}
-  {% include clients_teaser.html class="services-page__clients-teaser" title="You're in good company" featured_clients_only=true %}
+  {%- capture title -%}{% t services.clients-teaser-title %}{%- endcapture -%}
+  {% include clients_teaser.html class="services-page__clients-teaser" title=title featured_clients_only=true %}
   {% include compass_teaser.html class="services-page__compass-cta" %}
   {% include services_contact_form.liquid %}
 </main>


### PR DESCRIPTION
Fixes the issue of not having the clients teaser title translated to Spanish on the services overview page
