### PR TITLE
Slt 464/nav hide and reveal

### DIFF
--- a/src/_data/toggles.yml
+++ b/src/_data/toggles.yml
@@ -1,3 +1,3 @@
 example-of-a-released-feature: "on"
 example-of-an-unreleased-feature: "off"
-slt-464-hide-reveal-nav: "off"
+slt-464-hide-reveal-nav: "on"

--- a/src/_includes/website_header.liquid
+++ b/src/_includes/website_header.liquid
@@ -1,5 +1,5 @@
 {% if site.data.toggles.slt-464-hide-reveal-nav == 'on' %}
-  <header class="website-header">
+  <header class="website-header website-header--fixed-and-shown">
     {% include website_navigation.liquid %}
   </header>
 {% else %}  

--- a/src/_includes/website_header.liquid
+++ b/src/_includes/website_header.liquid
@@ -1,5 +1,5 @@
 {% if site.data.toggles.slt-464-hide-reveal-nav == 'on' %}
-  <header class="website-header website-header--fixed-and-shown">
+  <header class="website-header">
     {% include website_navigation.liquid %}
   </header>
 {% else %}  

--- a/src/assets/custom/css/_sass/_website-header.scss
+++ b/src/assets/custom/css/_sass/_website-header.scss
@@ -6,6 +6,10 @@
 }
 
 .website-header--fixed-and-shown {
-  position: fixed;
+  position: sticky;
   top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  background-color: white;
 }

--- a/src/assets/custom/css/_sass/_website-header.scss
+++ b/src/assets/custom/css/_sass/_website-header.scss
@@ -4,3 +4,8 @@
   padding-top: 15px;
   padding-bottom: 15px;
 }
+
+.website-header--fixed-and-shown {
+  position: fixed;
+  top: 0;
+}

--- a/src/assets/custom/css/_sass/_website-header.scss
+++ b/src/assets/custom/css/_sass/_website-header.scss
@@ -3,9 +3,6 @@
   height: 94px;
   padding-top: 15px;
   padding-bottom: 15px;
-}
-
-.website-header--fixed-and-shown {
   position: sticky;
   top: 0;
   left: 0;


### PR DESCRIPTION
We have decided to use `position: sticky` for the website header and have turned the feature toggle on, because to have the current header functionality without JS. We have tested this in IE, which falls back to a static navigation bar.