### PR TITLE
Fix Varying Tabber Height

### DIFF
--- a/src/assets/custom/css/_sass/_tabber.scss
+++ b/src/assets/custom/css/_sass/_tabber.scss
@@ -152,7 +152,7 @@
     padding-top: 35px;
   }
   @include large-and-extra-large {
-    min-height: 500px;
+    min-height: 540px;
   }
 }
 


### PR DESCRIPTION
This PR is for ticket number 470. 

It sets a slightly larger min-height in order for the height of the Tabber to remain the same. This prevents the background jumping position in relation to the Tabber as journey through each tab.