### PR TITLE
Make publications show on small screen 

### DIFF
--- a/src/assets/custom/css/_sass/_services-curated-publications.scss
+++ b/src/assets/custom/css/_sass/_services-curated-publications.scss
@@ -8,10 +8,14 @@
 
 .services__curated-publications--one-publication,
 .services__curated-publications--no-webinar {
-  &:first-child {
-    margin-top: -150px;
+  @include medium-large-and-extra-large {
+    &:first-child {
+      margin-top: -150px;
+    }
   }
+}
 
+.services__curated-publications--one-publication {
   @include small {
     display: none;
   }


### PR DESCRIPTION
This fixes is the issue of publications in service line pages being hidden on a small screen if there is only one publication or there is no webinar on the page