### PR TITLE
Ensure there is space for the +/- icon

### DIFF
--- a/src/assets/custom/css/_sass/_tabber.scss
+++ b/src/assets/custom/css/_sass/_tabber.scss
@@ -68,7 +68,7 @@
       content: attr(data-title);
       cursor: pointer;
       display: block;
-      padding: 10px;
+      padding: 10px 45px 10px 10px;
     }
     @include large-and-extra-large {
       display: none;


### PR DESCRIPTION
Ensure the tabber title always leaves space for the +/- icon on small screens.

This fixes bugs like the one described here:
https://codurance-online.leankit.com/card/1150256445

**Before**
<img width="472" alt="Screenshot 2020-07-03 at 14 41 24" src="https://user-images.githubusercontent.com/353044/86475498-b1638c00-bd3c-11ea-885f-d1a9402361b1.png">

**After**
<img width="475" alt="Screenshot 2020-07-03 at 14 56 51" src="https://user-images.githubusercontent.com/353044/86475936-7a41aa80-bd3d-11ea-97c6-190ed8100ce5.png">



