### PR TITLE
Release hide-reveal behaviour on Website Header

### DIFF
--- a/src/_data/toggles.yml
+++ b/src/_data/toggles.yml
@@ -1,4 +1,4 @@
 example-of-a-released-feature: "on"
 example-of-an-unreleased-feature: "off"
 slt-464-hide-reveal-nav: "on"
-slt-464-new-js: "off"
+slt-464-new-js: "on"


### PR DESCRIPTION
By turning this feature on we introduce the following behaviour to the website header.

- Scrolling up when the header is not in view reveals the header at the top of the viewport
- Scrolling down hides the header

**Related Lean Kit ticket [464 Reveal and hide navigation based on scrolling up and down](https://codurance-online.leankit.com/card/1136109509)**