### PR TITLE
Change orange to colour on the majority of remaining buttons and links

### DIFF
--- a/src/assets/custom/css/custom-global-styles.scss
+++ b/src/assets/custom/css/custom-global-styles.scss
@@ -150,14 +150,6 @@ h5 {
   background-color: $green !important;
 }
 
-.g-bg-coral {
-  background-color: $coral !important;
-}
-
-.g-bg-slate {
-  background-color: $slate !important;
-}
-
 .g-bg-orange {
   background-color: $orange !important;
 }

--- a/src/assets/custom/css/custom-global-styles.scss
+++ b/src/assets/custom/css/custom-global-styles.scss
@@ -150,6 +150,14 @@ h5 {
   background-color: $green !important;
 }
 
+.g-bg-coral {
+  background-color: $coral !important;
+}
+
+.g-bg-slate {
+  background-color: $slate !important;
+}
+
 .g-bg-orange {
   background-color: $orange !important;
 }
@@ -165,12 +173,12 @@ h5 {
 
 .u-pagination-v1-4:hover {
   color: #555 !important;
-  border-color: $orange !important;
+  border-color: $coral !important;
 }
 
 .u-pagination-v1-4--active {
-  background-color: $orange !important;
-  border-color: $orange !important;
+  background-color: $coral !important;
+  border-color: $coral !important;
 }
 
 /* Unify template overides
@@ -187,11 +195,11 @@ a:active {
   .navbar-nav:not([class*="u-main-nav-v"])
   .active
   > .nav-link {
-  color: $orange !important;
+  color: $coral !important;
 }
 
 .g-color-primary {
-  color: $orange !important;
+  color: $coral !important;
 }
 
 .lead {

--- a/src/assets/custom/css/custom-layout-2.scss
+++ b/src/assets/custom/css/custom-layout-2.scss
@@ -78,7 +78,7 @@ html {
   width: 25px;
   margin-left: 0;
   position: absolute;
-  background: linear-gradient(45deg, #ef4626 0%, #d60d47 100%);
+  background: $coral;
   border-radius: 2px;
   transition: all 0.3s ease;
 }
@@ -378,8 +378,8 @@ html {
 
 .btn-codurance-color {
   color: white;
-  background-color: $orange;
-  border-color: $orange;
+  background-color: $coral;
+  border-color: $coral;
 }
 
 .codurance-green-background {
@@ -625,7 +625,7 @@ i.no-border {
 
 .news-v1 a {
   /* 0 0 1 1 */
-  color: $orange-colour;
+  color: $coral;
 }
 
 /* Sponsoring section */

--- a/src/assets/custom/css/custom-layout-buttons.scss
+++ b/src/assets/custom/css/custom-layout-buttons.scss
@@ -24,16 +24,16 @@ $white-colour: #fff;
   font-size: 15px;
   margin: 10px 0;
   padding: 10px 30px;
-  background-color: transparent;
   color: white;
   font-weight: 700;
-  background: #ef7726;
+  background: $coral;
   border: none;
   overflow: hidden;
   position: relative;
 
   &:hover {
-    color: rgba(255, 255, 255, 0.8) !important;
+    color: white;
+    background: $coral--light;
   }
 
   span {


### PR DESCRIPTION
There will be a future commit for backgrounds to remove green and reset orange to coral. This commit does not cover Katylist.