### PR TITLE
Cazoo links

### DIFF
--- a/src/_data/clients.yml
+++ b/src/_data/clients.yml
@@ -34,7 +34,7 @@
   name: Cazoo
   image: /assets/custom/img/home/clients/cazoo-logo.png
   alt-text: Cazoo Logo
-  website: cazoo.co.uk
+  website: www.cazoo.co.uk
   services:
     - software_creation
 

--- a/src/_podcasts/2019-12-02-serverless.md
+++ b/src/_podcasts/2019-12-02-serverless.md
@@ -10,7 +10,7 @@ video-url: https://www.podbean.com/media/player/peu29-c9b917?from=yiiadmin&downl
 date: 2019-12-02 06:00:00 +00:00
 ---
 
-Today we are joined by the Chief Architect of [Cazoo](https://www.cazoo.co.uk) [Bob Gregory](https://twitter.com/bob_the_mighty) to talk to us about serverless and how to use it to help in the delivery of your project. [Jorge](https://codurance.com/publications/author/jorge-gueorguiev-garcia/) co-hosts with [Chris Bimson](https://github.com/christopher-bimson).
+Today we are joined by the Chief Architect of [Cazoo](https://www.cazoo.co.uk), [Bob Gregory](https://twitter.com/bob_the_mighty) to talk to us about serverless and how to use it to help in the delivery of your project. [Jorge](https://codurance.com/publications/author/jorge-gueorguiev-garcia/) co-hosts with [Chris Bimson](https://github.com/christopher-bimson).
 
 Photo: [Prairie Dog](https://pixabay.com/en/prairie-dog-singing-musical-rodent-1470659/) by DigiPD is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/deed.en)
 

--- a/src/_podcasts/2019-12-02-serverless.md
+++ b/src/_podcasts/2019-12-02-serverless.md
@@ -10,7 +10,7 @@ video-url: https://www.podbean.com/media/player/peu29-c9b917?from=yiiadmin&downl
 date: 2019-12-02 06:00:00 +00:00
 ---
 
-Today we are joined by the Chief Architect of [Cazoo](https://www.cazoo.co.uk), [Bob Gregory](https://twitter.com/bob_the_mighty) to talk to us about serverless and how to use it to help in the delivery of your project. [Jorge](https://codurance.com/publications/author/jorge-gueorguiev-garcia/) co-hosts with [Chris Bimson](https://github.com/christopher-bimson).
+Today we are joined by the Chief Architect of [Cazoo](https://www.cazoo.co.uk), [Bob Gregory](https://twitter.com/bob_the_mighty), to talk to us about serverless and how to use it to help in the delivery of your project. [Jorge](https://codurance.com/publications/author/jorge-gueorguiev-garcia/) co-hosts with [Chris Bimson](https://github.com/christopher-bimson).
 
 Photo: [Prairie Dog](https://pixabay.com/en/prairie-dog-singing-musical-rodent-1470659/) by DigiPD is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/deed.en)
 

--- a/src/_podcasts/2019-12-02-serverless.md
+++ b/src/_podcasts/2019-12-02-serverless.md
@@ -10,7 +10,7 @@ video-url: https://www.podbean.com/media/player/peu29-c9b917?from=yiiadmin&downl
 date: 2019-12-02 06:00:00 +00:00
 ---
 
-Today we are joined by the Chief Architect of [Cazoo](https://cazoo.co.uk) [Bob Gregory](https://twitter.com/bob_the_mighty) to talk to us about serverless and how to use it to help in the delivery of your project. [Jorge](https://codurance.com/publications/author/jorge-gueorguiev-garcia/) co-hosts with [Chris Bimson](https://github.com/christopher-bimson).
+Today we are joined by the Chief Architect of [Cazoo](https://www.cazoo.co.uk) [Bob Gregory](https://twitter.com/bob_the_mighty) to talk to us about serverless and how to use it to help in the delivery of your project. [Jorge](https://codurance.com/publications/author/jorge-gueorguiev-garcia/) co-hosts with [Chris Bimson](https://github.com/christopher-bimson).
 
 Photo: [Prairie Dog](https://pixabay.com/en/prairie-dog-singing-musical-rodent-1470659/) by DigiPD is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/deed.en)
 

--- a/src/_podcasts/2019-12-02-serverless.md
+++ b/src/_podcasts/2019-12-02-serverless.md
@@ -12,9 +12,11 @@ date: 2019-12-02 06:00:00 +00:00
 
 Today we are joined by the Chief Architect of [Cazoo](https://www.cazoo.co.uk), [Bob Gregory](https://twitter.com/bob_the_mighty), to talk to us about serverless and how to use it to help in the delivery of your project. [Jorge](https://codurance.com/publications/author/jorge-gueorguiev-garcia/) co-hosts with [Chris Bimson](https://github.com/christopher-bimson).
 
-Photo: [Prairie Dog](https://pixabay.com/en/prairie-dog-singing-musical-rodent-1470659/) by DigiPD is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/deed.en)
 
-
-Music: ["Sweeter Vermouth" by Kevin MacLeod](https://incompetech.com/music/royalty-free/music.html) is licensed under [CC-BY 3.0](http://creativecommons.org/licenses/by/3.0/)
-
-</sub>
+<small>
+  Photo: [Prairie Dog](https://pixabay.com/en/prairie-dog-singing-musical-rodent-1470659/) by DigiPD is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/deed.en)
+</small>
+  
+<small>
+  Music: ["Sweeter Vermouth" by Kevin MacLeod](https://incompetech.com/music/royalty-free/music.html) is licensed under [CC-BY 3.0](http://creativecommons.org/licenses/by/3.0/)
+</small>


### PR DESCRIPTION
Update links to Cazoo to use the www subdomain, as requested via @haletothewood. This affects the clients page and the link from the Serverless podcast:

https://codurance.com/clients
https://codurance.com/podcasts/2019-12-02-serverless/

In the Serverless podcast I've added a comma between the two links to make them clearer to read.

Lastly, there was a closing [`sub`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sub) tag in the HTML for the podcast with no opening tag. I have corrected this, using a [`small`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small) tag which seems more appropriate for accreditation of the photo and music.

