### PR TITLE
Fix links overlapping announcement slice when not visible

### DIFF
--- a/src/assets/custom/css/_sass/_website-navigation-sub-menus.scss
+++ b/src/assets/custom/css/_sass/_website-navigation-sub-menus.scss
@@ -27,6 +27,7 @@
     }
     &:not(.website-navigation-sub-menu--open) {
       opacity: 0;
+      pointer-events: none;
     }
   }
 }


### PR DESCRIPTION
This PR fixes a live issue where the links within the dropdown menus are still clickable when they are not visible.