### PR TITLE
SLT 558 Training Accordion Fix

### DIFF
--- a/src/_includes/accordion.liquid
+++ b/src/_includes/accordion.liquid
@@ -4,7 +4,7 @@
     {% capture active_class %} {% if forloop.first == true %}active{% endif %} {% endcapture %}
     <article id="{{ panel.id }}" class="accordion__panel accordion-panel {{ active_class }}" data-accordion_panel>
       <div class="accordion-panel__inner">
-        <div class="accordion-panel__header">
+        <div class="accordion-panel__header" data-accordion_panel_header>
           <h2 class="accordion-panel__title">{{ panel.title }}</h2>
         </div>
         <div class="accordion-panel__main">

--- a/src/assets/custom/css/_sass/_accordion.scss
+++ b/src/assets/custom/css/_sass/_accordion.scss
@@ -65,4 +65,5 @@
 
 .accordion-panel__title {
   @include freed-bold;
+  pointer-events: none;
 }

--- a/src/assets/custom/css/_sass/_accordion.scss
+++ b/src/assets/custom/css/_sass/_accordion.scss
@@ -65,5 +65,4 @@
 
 .accordion-panel__title {
   @include freed-bold;
-  pointer-events: none;
 }

--- a/src/assets/custom/js/accordion.js
+++ b/src/assets/custom/js/accordion.js
@@ -5,6 +5,7 @@
   var SELECTORS = {
     ACCORDION: "[data-accordion]",
     PANEL: "[data-accordion_panel]",
+    PANEL_HEADER: "accordion_panel_header",
     PANEL_ACTIVE: "[data-accordion_panel]." + ACTIVE_CLASS
   };
 
@@ -27,8 +28,11 @@
     });
   }
 
-  function handlePanelClick() {
-    togglePanel(this);
+  function handlePanelClick(e) {
+    if (SELECTORS.PANEL_HEADER in e.target.dataset) {
+      togglePanel(this);
+    }
+    return;
   }
 
   function togglePanel(panel) {

--- a/src/assets/custom/js/accordion.js
+++ b/src/assets/custom/js/accordion.js
@@ -29,7 +29,7 @@
   }
 
   function handlePanelClick(e) {
-    if (SELECTORS.PANEL_HEADER in e.target.dataset) {
+    if (SELECTORS.PANEL_HEADER in this.dataset) {
       togglePanel(this);
     }
     return;

--- a/src/assets/custom/js/accordion.js
+++ b/src/assets/custom/js/accordion.js
@@ -29,7 +29,7 @@
   }
 
   function handlePanelClick(e) {
-    if (SELECTORS.PANEL_HEADER in this.dataset) {
+    if (SELECTORS.PANEL_HEADER in e.target.dataset) {
       togglePanel(this);
     }
     return;


### PR DESCRIPTION
This PR fixes an issue when the accordion panels would collapse if the content of the panel is clicked.

Now panels will only open or collapse if the panel header is clicked.