### PR TITLE
Adapt single training template to work for all training pages

### DIFF
--- a/src/_data/trainings_en.yml
+++ b/src/_data/trainings_en.yml
@@ -47,6 +47,7 @@ functional-programming:
 
 lambdas:
   name: "Microservices with <br> AWS Lambdas"
+  duration: "DURATION: 2 Days"
   author: Mashooq Badar
   description: This course teaches your software delivery teams how to build and deploy microservices using AWS serverless architecture.
   page: /services/training/lambda-training

--- a/src/_includes/training_hero.liquid
+++ b/src/_includes/training_hero.liquid
@@ -15,13 +15,15 @@
   <div class="training-hero__details-wrapper">
     <div class="training-hero__details-wrapper-inner">
       <div class="training-hero__content-container">
-        <div class="training-hero__instructor-wrapper">
-          <span class="training-hero__instructor-avatar" style="background-image: url({{ site.baseurl }}{{ page.intro.instructor-avatar }})"></span>
-          <div class="training-hero__instructor-wrapper-inner">
-            <span class="training-hero__instructor-title">{{ training_data.course-instructor-title }}</span>
-            <span class="training-hero__instructor-name">{{ training_data.author }}</span>
+        {% if training_data.author == "Sandro Mancuso" %}
+          <div class="training-hero__instructor-wrapper">
+            <span class="training-hero__instructor-avatar" style="background-image: url({{ site.baseurl }}{{ page.intro.instructor-avatar }})"></span>
+            <div class="training-hero__instructor-wrapper-inner">
+              <span class="training-hero__instructor-title">{{ training_data.course-instructor-title }}</span>
+              <span class="training-hero__instructor-name">{{ training_data.author }}</span>
+            </div>
           </div>
-        </div>
+        {% endif %}
         <div class="training-hero__description-wrapper">
           <p class="training-hero__course-description {{ course-description-modifier }}">{{ training_data.description }}</p>
           {% include cta_primary_link.html href=href color='coral' text=text %}

--- a/src/_includes/training_hero.liquid
+++ b/src/_includes/training_hero.liquid
@@ -1,13 +1,13 @@
-{%- if include.instructor -%}
-  {%- assign course-description-modifier = training-hero__course-description--no-instructor -%}
-{%- endif -%}
-
+{% if training_data.author == "Sandro Mancuso" %}
+  {% assign course-description-modifier = "training-hero__course-description--with-instructor" %}
+  {% assign training-hero__intro-container-inner-modifier = "training-hero__intro-container-inner--with-instructor" %}
+{% endif %}
 {% capture text %}{% t single-training.contact-cta-button-text %}{% endcapture %}
 {% capture href %}#{% t get-in-touch.anchor-id %}{% endcapture %}
 
 <section class="training-hero">
   <div class="training-hero__intro-container" style="background-image: url({{ site.baseurl }}{{ page.intro.background-image }})">
-    <div class="training-hero__intro-container-inner"> 
+    <div class="training-hero__intro-container-inner {{ training-hero__intro-container-inner-modifier }}">
       <h1 class="training-hero__course-title">{{ training_data.name }}</h1>
       <span class="training-hero__course-duration">{{ training_data.duration }}</span>
     </div>

--- a/src/_includes/training_hero.liquid
+++ b/src/_includes/training_hero.liquid
@@ -1,13 +1,12 @@
 {% if training_data.author == "Sandro Mancuso" %}
-  {% assign course-description-modifier = "training-hero__course-description--with-instructor" %}
-  {% assign training-hero__intro-container-inner-modifier = "training-hero__intro-container-inner--with-instructor" %}
+  {% assign training-hero-modifier = "training-hero--with-instructor" %}
 {% endif %}
 {% capture text %}{% t single-training.contact-cta-button-text %}{% endcapture %}
 {% capture href %}#{% t get-in-touch.anchor-id %}{% endcapture %}
 
-<section class="training-hero">
+<section class="training-hero {{ training-hero-modifier }}">
   <div class="training-hero__intro-container" style="background-image: url({{ site.baseurl }}{{ page.intro.background-image }})">
-    <div class="training-hero__intro-container-inner {{ training-hero__intro-container-inner-modifier }}">
+    <div class="training-hero__intro-container-inner">
       <h1 class="training-hero__course-title">{{ training_data.name }}</h1>
       <span class="training-hero__course-duration">{{ training_data.duration }}</span>
     </div>
@@ -25,7 +24,7 @@
           </div>
         {% endif %}
         <div class="training-hero__description-wrapper">
-          <p class="training-hero__course-description {{ course-description-modifier }}">{{ training_data.description }}</p>
+          <p class="training-hero__course-description">{{ training_data.description }}</p>
           {% include cta_primary_link.html href=href color='coral' text=text %}
         </div>
       </div>

--- a/src/_layouts/single_training.liquid
+++ b/src/_layouts/single_training.liquid
@@ -11,13 +11,19 @@ layout: default
 
 {% include training_hero.liquid %}
 
-<section class="single-training__accordion">
+{% if training_data.author == "Sandro Mancuso" %}
+  {% assign accordion-modifier = "single-training__accordion--with-bio" %}
+{% endif %}
+
+<section class="single-training__accordion {{ accordion-modifier }}">
   {%- include accordion.liquid accordion_data=accordion_data -%}
 </section>
 
-<section class="single-training__instructor-bio">
-  {% include training_instructor_bio.liquid %}
-</section>
+{% if training_data.author == "Sandro Mancuso" %}
+  <section class="single-training__instructor-bio">
+    {% include training_instructor_bio.liquid %}
+  </section>
+{% endif %}
 
 {%- capture title -%}{% t services.clients-teaser-title %}{%- endcapture -%}
 {% include clients_teaser.html class="services-page__clients-teaser" client_ids=site.data.client_ids_by_page.single-training-pages title=title %}

--- a/src/assets/custom/css/_sass/_single-training.scss
+++ b/src/assets/custom/css/_sass/_single-training.scss
@@ -1,8 +1,6 @@
 .single-training__accordion {
   background-color: $navy--ultralight;
-  @include small {
-    padding-bottom: $vertical-overlap * 3.5;
-  }
+
   @include medium {
     padding-top: 50px;
   }
@@ -14,6 +12,9 @@
     @include max-width--framed;
   }
   &.single-training__accordion--with-bio {
+    @include small {
+      padding-bottom: $vertical-overlap * 3.5;
+    }
     @include large-and-extra-large {
       padding-bottom: $vertical-overlap * 2.5;
     }

--- a/src/assets/custom/css/_sass/_single-training.scss
+++ b/src/assets/custom/css/_sass/_single-training.scss
@@ -1,17 +1,22 @@
 .single-training__accordion {
   background-color: $navy--ultralight;
   @include small {
-    padding-bottom: ($vertical-overlap * 3.5);
+    padding-bottom: $vertical-overlap * 3.5;
   }
   @include medium {
     padding-top: 50px;
   }
   @include large-and-extra-large {
-    padding-bottom: ($vertical-overlap * 2.5);
+    padding-bottom: 50px;
     padding-top: 100px;
   }
   @include extra-large {
     @include max-width--framed;
+  }
+  &.single-training__accordion--with-bio {
+    @include large-and-extra-large {
+      padding-bottom: $vertical-overlap * 2.5;
+    }
   }
 }
 

--- a/src/assets/custom/css/_sass/_training-hero.scss
+++ b/src/assets/custom/css/_sass/_training-hero.scss
@@ -47,6 +47,13 @@ $form-width: 385px;
     position: relative;
     z-index: 2;
   }
+
+  &:not(.training-hero__intro-container-inner--with-instructor) {
+    transform: translateY(60px);
+    @include small {
+      transform: translateY(20px);
+    }
+  }
 }
 
 .training-hero__course-title {
@@ -142,27 +149,15 @@ $form-width: 385px;
 .training-hero__course-description {
   color: white;
 
-  &:not(.training-hero__course-description--no-instructor) {
-    padding-top: 25px;
-  }
-
-  &.training-hero__course-description--no-instructor {
-    @include medium {
-      padding-top: 60px;
-    }
-
-    @include large-and-extra-large {
-      padding-top: 70px;
-    }
-  }
-
   @include small {
     @include base;
     padding-bottom: 30px;
+    padding-top: 55px;
   }
 
   @include medium {
     padding-bottom: 20px;
+    padding-top: 60px;
   }
 
   @include medium-and-large {
@@ -171,11 +166,16 @@ $form-width: 385px;
 
   @include large-and-extra-large {
     padding-right: 60px;
+    padding-top: 70px;
   }
 
   @include extra-large {
     @include freed;
   }
+}
+
+.training-hero__course-description--with-instructor {
+  padding-top: 25px;
 }
 
 .cta--primary-coral {

--- a/src/assets/custom/css/_sass/_training-hero.scss
+++ b/src/assets/custom/css/_sass/_training-hero.scss
@@ -196,9 +196,7 @@ $form-width: 385px;
   padding: 30px;
   position: absolute;
   right: $lateral-space--large;
-  top: 50%;
   width: 350px;
-  transform: translateY(-50%);
 
   @include small-and-medium {
     display: none;
@@ -208,7 +206,12 @@ $form-width: 385px;
   }
 
   .training-hero:not(.training-hero--with-instructor) & {
-    transform: translateY(-85%);
+    bottom: 90px;
+  }
+
+  .training-hero--with-instructor & {
+    top: 50%;
+    transform: translateY(-50%);
   }
 }
 

--- a/src/assets/custom/css/_sass/_training-hero.scss
+++ b/src/assets/custom/css/_sass/_training-hero.scss
@@ -206,6 +206,10 @@ $form-width: 385px;
   @include medium-large-and-extra-large {
     @include style-card-box-shadow;
   }
+
+  .training-hero:not(.training-hero--with-instructor) & {
+    transform: translateY(-85%);
+  }
 }
 
 .training-hero-contact-cta__title {

--- a/src/assets/custom/css/_sass/_training-hero.scss
+++ b/src/assets/custom/css/_sass/_training-hero.scss
@@ -48,7 +48,7 @@ $form-width: 385px;
     z-index: 2;
   }
 
-  &:not(.training-hero__intro-container-inner--with-instructor) {
+  .training-hero:not(.training-hero--with-instructor) & {
     transform: translateY(60px);
     @include small {
       transform: translateY(20px);
@@ -172,10 +172,10 @@ $form-width: 385px;
   @include extra-large {
     @include freed;
   }
-}
 
-.training-hero__course-description--with-instructor {
-  padding-top: 25px;
+  .training-hero--with-instructor & {
+    padding-top: 25px;
+  }
 }
 
 .cta--primary-coral {

--- a/src/services/training/training-page-example/index.html
+++ b/src/services/training/training-page-example/index.html
@@ -9,7 +9,7 @@ image:
 metarobots: noindex,nofollow
 sitemap: false
 
-course: crafting-code-and-crafted-design
+course: lambdas
 
 intro:
    background-image: /assets/custom/img/training/training-page-example/training-hero-crafted-design.jpg


### PR DESCRIPTION
This makes our single training page template work for all courses, whether or not they include instructor info in the hero or an instructor bio section.