### PR TITLE
Remove styles which make cta text coral or orange after being clicked

### DIFF
--- a/src/assets/custom/css/custom-global-styles.scss
+++ b/src/assets/custom/css/custom-global-styles.scss
@@ -179,10 +179,7 @@ h5 {
 /* Unify template overides
    -------------------------------------- */
 
-a,
-a:hover,
-a:focus,
-a:active {
+a{
   color: $coral;
 }
 

--- a/src/assets/unify-1.9/css/theme-colors/orange.css
+++ b/src/assets/unify-1.9/css/theme-colors/orange.css
@@ -9,11 +9,7 @@
 a {
   color: #e67e22;
 }
-a:focus, 
-a:hover, 
-a:active {
-	color: #e67e22;
-}
+
 .color-green {
 	color: #e67e22;
 }

--- a/src/assets/unify-2.4/css/unify-core.css
+++ b/src/assets/unify-2.4/css/unify-core.css
@@ -23,11 +23,6 @@ a {
   outline: none;
 }
 
-a:focus,
-a:hover {
-  color: #fd851a;
-}
-
 .nav-link {
   color: #555;
 }


### PR DESCRIPTION
This fixes [the bug](https://codurance-online.leankit.com/card/1202978808) of text inside the cta's on the clients page 'disappearing' (being changed to the same colour as the CTA button background) after being clicked.