### PR TITLE
Fix accordion collapsing when contents are clicked

### DIFF
--- a/src/assets/custom/js/tabber.js
+++ b/src/assets/custom/js/tabber.js
@@ -26,6 +26,8 @@
 
   var PANELS = nodeListToArray(TABBER.querySelectorAll(SELECTORS.PANEL));
 
+  var clickedTargetPathArray;
+
   function isLargeScreen() {
     var largeScreenTabsAreVisible = LARGE_SCREEN_CONTROLS[0].scrollHeight > 0;
     return largeScreenTabsAreVisible;
@@ -71,23 +73,23 @@
     if (isLargeScreen()) {
       return;
     }
-    var clickedTargetPathArray = e.path;
+    clickedTargetPathArray = e.path;
 
     togglePanel(this, clickedTargetPathArray);
   }
 
-  function togglePanel(panel, clickedTargetPathArray) {
+  function togglePanel(panel) {
     var panelIsActive = panel.classList.contains(ACTIVE_CLASS);
 
     if (panelIsActive) {
-      makePanelInactive(panel, clickedTargetPathArray);
+      makePanelInactive(panel);
     } else {
       makePanelActive(panel);
       scrollToPanel(panel);
     }
   }
 
-  function makePanelInactive(panel, clickedTargetPathArray) {
+  function makePanelInactive(panel) {
     for (var i = 0; i < clickedTargetPathArray.length; i++) {
       if(clickedTargetPathArray[i].className === SELECTORS.TABBER_INNER){
         return;

--- a/src/assets/custom/js/tabber.js
+++ b/src/assets/custom/js/tabber.js
@@ -7,6 +7,7 @@
 
   var SELECTORS = {
     TABBER: "[data-tabber]",
+    TABBER_INNER: "tabber-panel__inner",
     LARGE_SCREEN_CONTROL: "[data-large_screen_control]",
     LARGE_SCREEN_CONTROL_ACTIVE: "[data-large_screen_control]." + ACTIVE_CLASS,
     PANEL: "[data-tabber_panel]",
@@ -66,26 +67,33 @@
     newPanel && newPanel.classList.add(ACTIVE_CLASS);
   }
 
-  function handlePanelClick() {
+  function handlePanelClick(e) {
     if (isLargeScreen()) {
       return;
     }
+    var clickedTargetPathArray = e.path;
 
-    togglePanel(this);
+    togglePanel(this, clickedTargetPathArray);
   }
 
-  function togglePanel(panel) {
+  function togglePanel(panel, clickedTargetPathArray) {
     var panelIsActive = panel.classList.contains(ACTIVE_CLASS);
 
     if (panelIsActive) {
-      makePanelInactive(panel);
+      makePanelInactive(panel, clickedTargetPathArray);
     } else {
       makePanelActive(panel);
       scrollToPanel(panel);
     }
   }
 
-  function makePanelInactive(panel) {
+  function makePanelInactive(panel, clickedTargetPathArray) {
+    for (var i = 0; i < clickedTargetPathArray.length; i++) {
+      if(clickedTargetPathArray[i].className === SELECTORS.TABBER_INNER){
+        return;
+      }
+    }
+
     panel.classList.remove(ACTIVE_CLASS);
     const relatedTab = TABBER.querySelector(
       SELECTORS.LARGE_SCREEN_CONTROL_ACTIVE


### PR DESCRIPTION
This fixes [a bug on the service line pages ](https://codurance-online.leankit.com/card/1200399192) whereby if you click on the content of an open accordion panel, the panel closes. We don't want this. Instead we want the panel only to close if the title bar of the panel is clicked. 
