### PR TITLE
Add canonical tags to pages that don't already have one

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -14,6 +14,8 @@
 
 {% if page.canonical %}
   <link rel="canonical" href="{{ page.canonical.href }}" />
+{% else %}
+  <link rel="canonical" href="https://codurance.com{{ page.url }}" />
 {% endif %}
 
 <!-- fonts -->


### PR DESCRIPTION
Adds canonical tags to all pages so that search engines are able to detect that the 'main' page is the EN version. EN versions also have them as this is best practice. Some blog posts currently have canonical tags pointing to the author's personal blog. These have been left as they are for now as it is best practice to have only one canonical tag per page. This can quite easily be changed in the future if we want.
