### PR TITLE
Fix submenu screen resize issue

### DIFF
--- a/src/assets/custom/js/websiteNavigation.js
+++ b/src/assets/custom/js/websiteNavigation.js
@@ -177,8 +177,18 @@ var websiteNavigation = function () {
     };
   }
 
+  function handleResizingFromSmallToLargeScreenWhenASubmenuIsOpen() {
+    window.onresize = function () {
+      if (header.classList.contains(HEADER_HAS_OPEN_SUBMENU_CLASS) && window.innerWidth > 768 ){
+        location.reload();
+        openSubMenu();
+      }
+    };
+  }
+
   setupEventListeners();
   exposeSharedMethods();
+  handleResizingFromSmallToLargeScreenWhenASubmenuIsOpen();
 };
 
 window.addEventListener('DOMContentLoaded', websiteNavigation);


### PR DESCRIPTION
There was a bug whereby when you were on a small screen and had the navigation menu open, and opened a submenu, if you then widen the window to a larger size, all of the page elements were hidden. This is a quick temporary fix that reloads the page when this happens. 
