### PR TITLE
Enable Cazoo Case Study Download for ES Pages

### DIFF
--- a/src/_includes/service_line_case_studies.liquid
+++ b/src/_includes/service_line_case_studies.liquid
@@ -19,7 +19,7 @@
       </div>
     </div>
 
-    {%- if site.lang == 'en' and include.service_line == 'specialist-expertise' or include.service_line == 'software-delivery'  -%}
+    {%- if include.service_line == 'specialist-expertise' or include.service_line == 'software-delivery'  -%}
       <div class="service-line-case-studies__card">
         <div class="case-studies__card-image" style="background-image: url(https://f.hubspotusercontent10.net/hubfs/3042464/Cazoo%20Case%20Study/Case%20Studies%20Thumb.jpg);">
         </div>


### PR DESCRIPTION
This PR enables the download of the Cazoo case study for the ES versions of the Software Delivery and Specialist Expertise pages.